### PR TITLE
Use options prefixes

### DIFF
--- a/demos/burgers-time_dep.py
+++ b/demos/burgers-time_dep.py
@@ -45,7 +45,7 @@ def get_solver(mesh_seq):
         t = t_start
         qoi = mesh_seq.qoi
         while t < t_end - 1.0e-05:
-            solve(F == 0, u)
+            solve(F == 0, u, options_prefix='uv_2d')
             mesh_seq.J += qoi({'uv_2d': u}, t)
             u_.assign(u)
             t += dt
@@ -102,7 +102,7 @@ solutions = mesh_seq.solve_adjoint()
 fig, axes = plot_snapshots(solutions, P, 'uv_2d', 'adjoint', levels=np.linspace(0, 2.1, 9))
 fig.savefig("burgers3-time_integrated.jpg")
 
-# .. figure:: burgers3-time_integrated.jpg
+# .. figure:: burgers-time_integrated.jpg
 #    :figwidth: 90%
 #    :align: center
 #
@@ -110,4 +110,4 @@ fig.savefig("burgers3-time_integrated.jpg")
 # has a source term at the right hand boundary, rather
 # than a instantaneous pulse at the terminal time.
 #
-# This demo can also be accessed as a `Python script <burgers3.py>`__.
+# This demo can also be accessed as a `Python script <burgers-time_integrated.py>`__.

--- a/demos/burgers-time_integrated.py
+++ b/demos/burgers-time_integrated.py
@@ -100,7 +100,7 @@ solutions = mesh_seq.solve_adjoint()
 # Finally, plot snapshots of the adjoint solution. ::
 
 fig, axes = plot_snapshots(solutions, P, 'uv_2d', 'adjoint', levels=np.linspace(0, 2.1, 9))
-fig.savefig("burgers3-time_integrated.jpg")
+fig.savefig("burgers-time_integrated.jpg")
 
 # .. figure:: burgers-time_integrated.jpg
 #    :figwidth: 90%

--- a/demos/burgers2.py
+++ b/demos/burgers2.py
@@ -65,7 +65,8 @@ fig.savefig("burgers2-end_time.jpg")
 # solution change when the solution is trasferred between different
 # meshes?
 #
-# In the `next demo <./burgers3.py.html>`__, we solve the same problem
-# but with a QoI involving an integral in time, as well as space.
+# In the `next demo <./burgers-time_integrated.py.html>`__, we solve
+# the same problem but with a QoI involving an integral in time, as
+# well as space.
 #
 # This demo can also be accessed as a `Python script <burgers2.py>`__.

--- a/demos/time_partition.py
+++ b/demos/time_partition.py
@@ -65,10 +65,11 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True)
 #
 # This partition isn't particularly interesting.
 # Let's try constructing a new one with more
-# than one subinterval. ::
+# than one subinterval. (Note that ``pyrint``
+# accounts for printing in parallel.) ::
 
 num_subintervals = 2
-print('')
+pyrint('')
 P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
                   solves_per_timestep=2, timesteps_per_export=2)
 
@@ -78,7 +79,7 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
 # for that, it is possible to specify a list of
 # timesteps corresponding to each subinterval. ::
 
-print('')
+pyrint('')
 dt = [0.125, 0.0625]
 P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
                   timesteps_per_export=2)
@@ -88,7 +89,7 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
 # This can be remedied by also setting
 # ``timesteps_per_export`` as a list. ::
 
-print('')
+pyrint('')
 P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
                   timesteps_per_export=[2, 4])
 
@@ -98,7 +99,7 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
 # non-uniform subintervals, they need to be passed
 # to the constructor as a list of tuples. ::
 
-print('')
+pyrint('')
 subintervals = [(0.0, 0.75), (0.75, 1.0)]
 P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
                   timesteps_per_export=[2, 4], subintervals=subintervals)

--- a/demos/time_partition.py
+++ b/demos/time_partition.py
@@ -37,24 +37,18 @@ fields = ['solution']
 # With these definitions, we should get
 # a subinterval of :math:`(0,1]` containing
 # eight timesteps. When constructing a
-# :class:`TimePartition`, it is often useful
-# to use the ``debug`` flag to check that it
-# is constructed correctly. ::
+# :class:`TimePartition` (or any other object),
+# it is often useful to use Pyroteus' debugging
+# mode. This is specified using ``set_log_level``. ::
 
-P = TimePartition(end_time, num_subintervals, dt, fields, debug=True)
+set_log_level(DEBUG)
+P = TimePartition(end_time, num_subintervals, dt, fields)
 
 # Notice that one of the things which is printed
-# out is ``solves_per_timestep``. This value
-# defaults to one, but can be set to larger
-# values to account for the case where your
-# PDE has multiple linear or nonlinear solves
-# per timestep.
-#
-# There is also a quantity ``timesteps_per_export``,
-# which controls how frequently data is to be
-# exported to file during a simulation. It
-# also defaults to one, but may be specified
-# as a keyword argument.
+# out is ``timesteps_per_export``, which controls
+# how frequently data is to be exported to file
+# during a simulation. It defaults to one, but may
+# be specified as a keyword argument.
 #
 # Based on the above values, the
 # :class:`TimePartition` computes the number
@@ -65,13 +59,11 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True)
 #
 # This partition isn't particularly interesting.
 # Let's try constructing a new one with more
-# than one subinterval. (Note that ``pyrint``
-# accounts for printing in parallel.) ::
+# than one subinterval. ::
 
 num_subintervals = 2
-pyrint('')
-P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
-                  solves_per_timestep=2, timesteps_per_export=2)
+P = TimePartition(end_time, num_subintervals, dt, fields,
+                  timesteps_per_export=2)
 
 # In some problems, the dynamics evolve such
 # that different timesteps are suitable during
@@ -79,9 +71,8 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
 # for that, it is possible to specify a list of
 # timesteps corresponding to each subinterval. ::
 
-pyrint('')
 dt = [0.125, 0.0625]
-P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
+P = TimePartition(end_time, num_subintervals, dt, fields,
                   timesteps_per_export=2)
 
 # Note that this means that there are more
@@ -89,8 +80,7 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
 # This can be remedied by also setting
 # ``timesteps_per_export`` as a list. ::
 
-pyrint('')
-P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
+P = TimePartition(end_time, num_subintervals, dt, fields,
                   timesteps_per_export=[2, 4])
 
 # So far, we have assumed that the subintervals
@@ -99,9 +89,8 @@ P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
 # non-uniform subintervals, they need to be passed
 # to the constructor as a list of tuples. ::
 
-pyrint('')
 subintervals = [(0.0, 0.75), (0.75, 1.0)]
-P = TimePartition(end_time, num_subintervals, dt, fields, debug=True,
+P = TimePartition(end_time, num_subintervals, dt, fields,
                   timesteps_per_export=[2, 4], subintervals=subintervals)
 
 #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,7 +172,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/2.7/', None),
     'ufl': ('https://fenics.readthedocs.io/projects/ufl/en/latest/', None),
-    'firedrake': ('http://firedrakeproject.org/', None),
+    'firedrake': ('https://firedrakeproject.org/', None),
 }
 
 autoclass_content = "both"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,4 +55,4 @@ earlier ones.
     Burgers equation on a sequence of meshes <demos/burgers.py>
     Adjoint of Burgers equation <demos/burgers1.py>
     Adjoint of Burgers equation on two meshes <demos/burgers2.py>
-    Adjoint of Burgers equation with a time-integrated QoI <demos/burgers3.py>
+    Adjoint of Burgers equation with a time-integrated QoI <demos/burgers-time_integrated.py>

--- a/makefile
+++ b/makefile
@@ -25,10 +25,10 @@ demo:
 	@cd demos && python3 burgers.py
 	@cd demos && python3 burgers1.py
 	@cd demos && python3 burgers2.py
-	@cd demos && python3 burgers3.py
+	@cd demos && python3 burgers-time_integrated.py
 	@echo "Done."
 
-doc:
+doc: demo
 	@echo "Building docs in html format..."
 	@cd docs && make html
 	@echo "Done."

--- a/pyroteus/__init__.py
+++ b/pyroteus/__init__.py
@@ -5,6 +5,7 @@ from pyroteus.recovery import *        # noqa
 from pyroteus.plot import *            # noqa
 from pyroteus.metric import *          # noqa
 from pyroteus.mesh_seq import *        # noqa
+from pyroteus.log import *             # noqa
 from pyroteus.interpolation import *   # noqa
 
 __version__ = '0.1'

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -5,7 +5,7 @@ import firedrake
 from firedrake_adjoint import pyadjoint
 from .interpolation import project
 from .mesh_seq import MeshSeq
-from .utility import AttrDict, norm, pyrint, warning
+from .utility import AttrDict, norm, warning
 from functools import wraps
 import numpy as np
 

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -221,7 +221,7 @@ class AdjointMeshSeq(MeshSeq):
             for field, fs in function_spaces.items():
 
                 # Get solve blocks
-                solve_blocks = self.time_partition.get_solve_blocks(field, subinterval=i)
+                solve_blocks = self.get_solve_blocks(field, subinterval=i)
                 num_solve_blocks = len(solve_blocks)
                 assert num_solve_blocks > 0, "Looks like no solves were written to tape!" \
                                              + " Does the solution depend on the initial condition?"

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -5,7 +5,7 @@ import firedrake
 from firedrake_adjoint import pyadjoint
 from .interpolation import project
 from .mesh_seq import MeshSeq
-from .utility import AttrDict, norm
+from .utility import AttrDict, norm, pyrint
 from functools import wraps
 import numpy as np
 
@@ -158,7 +158,7 @@ class AdjointMeshSeq(MeshSeq):
             solver_kwargs=solver_kwargs, run_final_subinterval=test_checkpoint_qoi,
         )
         if self.warn and np.isclose(float(self.J), 0.0):
-            print("WARNING: Zero QoI. Is it implemented as intended?")
+            pyrint("WARNING: Zero QoI. Is it implemented as intended?")
         J_chk = self.J
         self.J = 0
 
@@ -205,7 +205,7 @@ class AdjointMeshSeq(MeshSeq):
                 if self.qoi_type == 'end_time':
                     self.J = self.qoi(sols, **solver_kwargs.get('qoi_kwargs', {}))
                     if self.warn and np.isclose(float(self.J), 0.0):
-                        print("WARNING: Zero QoI. Is it implemented as intended?")
+                        pyrint("WARNING: Zero QoI. Is it implemented as intended?")
             else:
                 with pyadjoint.stop_annotating():
                     for field, fs in function_spaces.items():
@@ -247,6 +247,9 @@ class AdjointMeshSeq(MeshSeq):
                 sols = solutions[field]
                 stride = self.time_partition.timesteps_per_export[i]
                 for j, block in enumerate(solve_blocks[::stride]):
+                    pyrint(f"DEBUG: field {field}")  # FIXME for migrating_trench
+                    pyrint(f"DEBUG: lvalue space {sols.forward[i][j].function_space()}")
+                    pyrint(f"DEBUG: rvalue space {block._outputs[0].saved_output.function_space()}")
                     sols.forward[i][j].assign(block._outputs[0].saved_output)
                     sols.adjoint[i][j].assign(block.adj_sol)
                     if fwd_old_idx is not None:
@@ -266,9 +269,9 @@ class AdjointMeshSeq(MeshSeq):
                             raise IndexError(f"Cannot extract solve block {j*stride+1} "
                                              + f"> {num_solve_blocks}")
                 if self.warn and np.isclose(norm(solutions[field].adjoint[i][0]), 0.0):
-                    print(f"WARNING: Adjoint solution for field {field} on subinterval {i} is zero.")
+                    pyrint(f"WARNING: Adjoint solution for field {field} on subinterval {i} is zero.")
                 if self.warn and get_adj_values and np.isclose(norm(sols.adj_value[i][0]), 0.0):
-                    print(f"WARNING: Adjoint action for field {field} on subinterval {i} is zero.")
+                    pyrint(f"WARNING: Adjoint action for field {field} on subinterval {i} is zero.")
 
             # Get adjoint action
             seeds = {
@@ -278,9 +281,9 @@ class AdjointMeshSeq(MeshSeq):
             }
             for field, seed in seeds.items():
                 if self.warn and np.isclose(norm(seed), 0.0):
-                    print(f"WARNING: Adjoint action for field {field} on subinterval {i} is zero.")
+                    pyrint(f"WARNING: Adjoint action for field {field} on subinterval {i} is zero.")
                     if steady:
-                        print("  You seem to have a steady-state problem. Presumably it is linear?")
+                        pyrint("  You seem to have a steady-state problem. Presumably it is linear?")
             tape.clear_tape()
 
         # Check the QoI value agrees with that due to the checkpointing run

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -246,6 +246,10 @@ class AdjointMeshSeq(MeshSeq):
                 # Extract solution data
                 sols = solutions[field]
                 stride = self.time_partition.timesteps_per_export[i]
+                if len(solve_blocks[::stride]) >= self.time_partition.exports_per_subinterval[i]:
+                    raise ValueError("More solve blocks than expected"
+                                     + f" ({len(solve_blocks[::stride])} vs."
+                                     + f" {self.time_partition.exports_per_subinterval[i]})")
                 for j, block in enumerate(solve_blocks[::stride]):
                     sols.forward[i][j].assign(block._outputs[0].saved_output)
                     sols.adjoint[i][j].assign(block.adj_sol)

--- a/pyroteus/log.py
+++ b/pyroteus/log.py
@@ -1,0 +1,41 @@
+"""
+Loggers for Pyroteus.
+
+Code mostly copied from [the Thetis project](https://thetisproject.org).
+"""
+import firedrake
+import logging
+
+
+__all__ = ['logger', 'output_logger', 'debug', 'info', 'warning', 'error', 'critical', 'pyrint', 'set_log_level']
+
+
+def get_new_logger(name, fmt='%(levelname)s %(message)s'):
+    logger = logging.getLogger(name)
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt))
+    if firedrake.COMM_WORLD.rank != 0:
+        handler = logging.NullHandler()
+    logger.addHandler(handler)
+    return logger
+
+
+logger = get_new_logger('pyroteus')
+logger.setLevel(logging.WARNING)
+log = logger.log
+debug = logger.debug
+info = logger.info
+warning = logger.warning
+error = logger.error
+critical = logger.critical
+
+output_logger = get_new_logger('pyroteus_output', fmt='%(message)s')
+output_logger.setLevel(logging.INFO)
+pyrint = output_logger.info
+
+
+def set_log_level(level):
+    firedrake.set_log_level(level)
+    logger.setLevel(level)

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -2,7 +2,7 @@
 Sequences of meshes corresponding to a :class:`TimePartition`.
 """
 import firedrake
-from .utility import AttrDict, Mesh
+from .utility import AttrDict, Mesh, pyrint
 from .interpolation import project
 from collections.abc import Iterable
 
@@ -152,15 +152,15 @@ class MeshSeq(object):
         ]
         if len(fwd_old_idx) == 0:
             if not warned:
-                print("WARNING: Solve block has no dependencies")  # FIXME
+                pyrint("WARNING: Solve block has no dependencies")  # FIXME
                 warned = True
             fwd_old_idx = None
         else:
             if len(fwd_old_idx) > 1 and not warned:
-                print("WARNING: Solve block has dependencies in the prognostic space"
-                      + " other\n  than the PDE solution at the previous timestep."
-                      + f" (Dep indices {fwd_old_idx}).\n  Naively assuming the first"
-                      + " to be the right one.")  # FIXME
+                pyrint("WARNING: Solve block has dependencies in the prognostic space"
+                       + " other\n  than the PDE solution at the previous timestep."
+                       + f" (Dep indices {fwd_old_idx}).\n  Naively assuming the first"
+                       + " to be the right one.")  # FIXME
                 warned = True
             fwd_old_idx = fwd_old_idx[0]
         return fwd_old_idx, warned

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -2,9 +2,9 @@
 Sequences of meshes corresponding to a :class:`TimePartition`.
 """
 import firedrake
-from .log import debug
-from .utility import AttrDict, Mesh, pyrint
 from .interpolation import project
+from .log import debug, warning
+from .utility import AttrDict, Mesh
 from collections.abc import Iterable
 
 
@@ -147,7 +147,7 @@ class MeshSeq(object):
         # Get all blocks
         blocks = get_working_tape().get_blocks()
         if len(blocks) == 0:
-            pyrint("WARNING: tape has no blocks!")
+            warning("Tape has no blocks!")
             return blocks
 
         # Restrict to solve blocks
@@ -205,15 +205,14 @@ class MeshSeq(object):
         ]
         if len(fwd_old_idx) == 0:
             if not warned:
-                pyrint("WARNING: Solve block has no dependencies")  # FIXME
+                warning("Solve block has no dependencies")  # FIXME
                 warned = True
             fwd_old_idx = None
         else:
             if len(fwd_old_idx) > 1 and not warned:
-                pyrint("WARNING: Solve block has dependencies in the prognostic space"
-                       + " other\n  than the PDE solution at the previous timestep."
-                       + f" (Dep indices {fwd_old_idx}).\n  Naively assuming the first"
-                       + " to be the right one.")  # FIXME
+                warning("Solve block has dependencies in the prognostic space other than the\n"
+                        + f" PDE solution at the previous timestep. (Dep indices {fwd_old_idx}).\n"
+                        + " Naively assuming the first to be the right one.")  # FIXME
                 warned = True
             fwd_old_idx = fwd_old_idx[0]
         return fwd_old_idx, warned

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -4,7 +4,7 @@ Sequences of meshes corresponding to a :class:`TimePartition`.
 import firedrake
 from .utility import AttrDict, Mesh
 from .interpolation import project
-from collections import Iterable
+from collections.abc import Iterable
 
 
 __all__ = ["MeshSeq"]

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -3,7 +3,7 @@ Sequences of meshes corresponding to a :class:`TimePartition`.
 """
 import firedrake
 from .interpolation import project
-from .log import debug, warning
+from .log import warning
 from .utility import AttrDict, Mesh
 from collections.abc import Iterable
 

--- a/pyroteus/thetis_compat.py
+++ b/pyroteus/thetis_compat.py
@@ -1,0 +1,39 @@
+try:
+    from thetis import *
+except ImportError:
+    raise ImportError("Thetis is not installed!")
+
+
+class FlowSolver2d(thetis.solver2d.FlowSolver2d):
+    """
+    Augmented version of Thetis' ``FlowSolver2d``
+    class which accounts for restarting the
+    simulation on a new mesh and modifying
+    options prefixes.
+    """
+
+    def update_options_prefixes(self):
+        if not hasattr(self, 'timestepper'):
+            self.create_timesteppers()
+        if hasattr(self.timestepper, 'timesteppers'):
+            for field, ts in self.timestepper.timesteppers.items():
+                self.timestepper.timesteppers[field].name = field
+                self.timestepper.timesteppers[field].update_solver()
+        else:
+            self.timestepper.name = 'swe2d'
+            self.timestepper.update_solver()
+
+    def iterate(self, **kwargs):
+        self.update_options_prefixes()
+        super(FlowSolver2d, self).iterate(**kwargs)
+
+    def correct_counters(self, ts_data):
+        i_export = int(ts_data.start_time/ts_data.timestep/ts_data.timesteps_per_export)
+        self.simulation_time = ts_data.start_time
+        self.i_export = i_export
+        self.next_export_t = ts_data.start_time
+        self.iteration = int(ts_data.start_time/ts_data.timestep)
+        self.export_initial_state = np.isclose(ts_data.start_time, 0.0)
+        if not self.options.no_exports and len(self.options.fields_to_export) > 0:
+            for e in self.exporters['vtk'].exporters:
+                self.exporters['vtk'].exporters[e].set_next_export_ix(i_export)

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -2,7 +2,7 @@
 Partitioning for the temporal domain.
 """
 from .log import debug
-from .utility import AttrDict, pyrint
+from .utility import AttrDict
 from collections.abc import Iterable
 import numpy as np
 

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -37,6 +37,7 @@ class TimePartition(object):
             of subintervals, which need not be of
             uniform length (defaults to None)
         """
+        debug('')
         if isinstance(fields, str):
             fields = [fields]
         self.fields = fields

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -33,10 +33,6 @@ class TimePartition(object):
             timesteps per export (default 1)
         :kwarg start_time: start time of the
             interval of interest (default 0.0)
-        :kwarg solves_per_timestep: (list of)
-            (non)linear solves per timestep
-            corresponding to the fields (defaults
-            to 1 for each)
         :kwarg subinterals: user-provided sequence
             of subintervals, which need not be of
             uniform length (defaults to None)
@@ -50,13 +46,6 @@ class TimePartition(object):
         self.num_subintervals = int(np.round(num_subintervals))
         if not np.isclose(num_subintervals, self.num_subintervals):
             raise ValueError(f"Non-integer number of subintervals {num_subintervals}")
-        solves_per_timestep = kwargs.get('solves_per_timestep', [1 for field in fields])
-        if not isinstance(solves_per_timestep, Iterable):
-            solves_per_timestep = [solves_per_timestep]
-        self.solves_per_timestep = [int(np.round(spts)) for spts in solves_per_timestep]
-        if not np.allclose(solves_per_timestep, self.solves_per_timestep):
-            raise ValueError(f"Non-integer number of solves per timestep {solves_per_timestep}")
-        self.print("solves_per_timestep")
         self.debug("num_subintervals")
         self.interval = (self.start_time, self.end_time)
         self.debug("interval")
@@ -156,61 +145,6 @@ class TimePartition(object):
             'start_time': self.subintervals[i][0],
             'end_time': self.subintervals[i][1],
         })
-
-    def get_solve_blocks(self, field, subinterval=0, has_adj_sol=True):
-        """
-        Get all blocks of the tape corresponding to
-        solve steps for prognostic solution ``field``
-        on a given ``subinterval``.
-        """
-        from firedrake.adjoint.blocks import GenericSolveBlock, ProjectBlock
-        from pyadjoint import get_working_tape
-
-        # Get all blocks
-        blocks = get_working_tape().get_blocks()
-        if len(blocks) == 0:
-            pyrint("WARNING: tape has no blocks!")
-            return blocks
-
-        # Restrict to solve blocks
-        solve_blocks = [
-            block
-            for block in blocks
-            if issubclass(block.__class__, GenericSolveBlock)
-            and not issubclass(block.__class__, ProjectBlock)
-        ]
-
-        # Restrict to solve blocks with adjoint solutions
-        if has_adj_sol:
-            solve_blocks = [
-                block
-                for block in solve_blocks
-                if block.adj_sol is not None
-            ]
-
-        # Slice solve blocks by field
-        stride = sum(self.solves_per_timestep)
-        offset = sum(self.solves_per_timestep[:self.fields.index(field) + 1])
-        offset -= self.timesteps_per_subinterval[subinterval]*stride
-        if self.debug:
-            pyrint("Solve blocks before slicing:")
-            for i, block in enumerate(solve_blocks):
-                pyrint(f"{i:4d}: {type(block)} {block.options_prefix}")
-            pyrint(f"Offset = {offset}")
-            pyrint(f"Stride = {stride}")
-        solve_blocks = solve_blocks[offset::stride]
-        if self.debug:
-            pyrint("Solve blocks after slicing:")
-            for i, block in enumerate(solve_blocks):
-                pyrint(f"{i:4d}: {type(block)} {block.options_prefix}")
-
-        # Check FunctionSpaces are consistent across solve blocks
-        element = solve_blocks[0].function_space.ufl_element()
-        for block in solve_blocks:
-            if element != block.function_space.ufl_element():
-                raise ValueError(f"Solve block list for field {field} contains mismatching"
-                                 + f" elements ({element} vs. {block.function_space.ufl_element()})")
-        return solve_blocks
 
 
 class TimeInterval(TimePartition):

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -1,7 +1,7 @@
 """
 Partitioning for the temporal domain.
 """
-from .utility import AttrDict
+from .utility import AttrDict, pyrint
 from collections.abc import Iterable
 import numpy as np
 
@@ -138,7 +138,7 @@ class TimePartition(object):
             raise AttributeError(f"Attribute {attr} cannot be printed because it doesn't exist")
         label = ' '.join(attr.split('_'))
         if self.debug:
-            print(f"TimePartition: {label:25s} {val}")
+            pyrint(f"TimePartition: {label:25s} {val}")
 
     def __len__(self):
         return self.num_subintervals
@@ -170,7 +170,7 @@ class TimePartition(object):
         # Get all blocks
         blocks = get_working_tape().get_blocks()
         if len(blocks) == 0:
-            print("WARNING: tape has no blocks!")
+            pyrint("WARNING: tape has no blocks!")
             return blocks
 
         # Restrict to solve blocks
@@ -194,16 +194,24 @@ class TimePartition(object):
         offset = sum(self.solves_per_timestep[:self.fields.index(field) + 1])
         offset -= self.timesteps_per_subinterval[subinterval]*stride
         if self.debug:
-            print("Solve blocks before slicing:")
+            pyrint("Solve blocks before slicing:")
             for i, block in enumerate(solve_blocks):
+<<<<<<< HEAD
                 pyrint(f"{i:4d}: {type(block)} {block.options_prefix}")
+=======
+                pyrint(f"{i:4d}: {type(block)}")
+>>>>>>> 54016e0... log: print -> pyrint
             pyrint(f"Offset = {offset}")
             pyrint(f"Stride = {stride}")
         solve_blocks = solve_blocks[offset::stride]
         if self.debug:
-            print("Solve blocks after slicing:")
+            pyrint("Solve blocks after slicing:")
             for i, block in enumerate(solve_blocks):
+<<<<<<< HEAD
                 pyrint(f"{i:4d}: {type(block)} {block.options_prefix}")
+=======
+                pyrint(f"{i:4d}: {type(block)}")
+>>>>>>> 54016e0... log: print -> pyrint
 
         # Check FunctionSpaces are consistent across solve blocks
         element = solve_blocks[0].function_space.ufl_element()

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -196,22 +196,14 @@ class TimePartition(object):
         if self.debug:
             pyrint("Solve blocks before slicing:")
             for i, block in enumerate(solve_blocks):
-<<<<<<< HEAD
                 pyrint(f"{i:4d}: {type(block)} {block.options_prefix}")
-=======
-                pyrint(f"{i:4d}: {type(block)}")
->>>>>>> 54016e0... log: print -> pyrint
             pyrint(f"Offset = {offset}")
             pyrint(f"Stride = {stride}")
         solve_blocks = solve_blocks[offset::stride]
         if self.debug:
             pyrint("Solve blocks after slicing:")
             for i, block in enumerate(solve_blocks):
-<<<<<<< HEAD
                 pyrint(f"{i:4d}: {type(block)} {block.options_prefix}")
-=======
-                pyrint(f"{i:4d}: {type(block)}")
->>>>>>> 54016e0... log: print -> pyrint
 
         # Check FunctionSpaces are consistent across solve blocks
         element = solve_blocks[0].function_space.ufl_element()

--- a/pyroteus/utility.py
+++ b/pyroteus/utility.py
@@ -4,6 +4,7 @@ Utility functions and classes for mesh adaptation.
 from __future__ import absolute_import
 import firedrake
 from firedrake import *
+from .log import *
 from collections import OrderedDict
 
 

--- a/test/burgers.py
+++ b/test/burgers.py
@@ -38,7 +38,9 @@ def get_solver(self):
     def solver(i, ic):
         t_start, t_end = self.time_partition[i].subinterval
         dt = self.time_partition[i].timestep
-        fs = ic['uv_2d'].function_space()
+        fs = self.function_spaces['uv_2d'][i]
+
+        # Specify constants
         dtc = Constant(dt)
         nu = Constant(0.0001)
 

--- a/test/burgers.py
+++ b/test/burgers.py
@@ -58,7 +58,7 @@ def get_solver(self):
         t = t_start
         qoi = self.qoi
         while t < t_end - 1.0e-05:
-            solve(F == 0, u)
+            solve(F == 0, u, options_prefix='uv_2d')
             if self.qoi_type == 'time_integrated':
                 self.J += qoi({'uv_2d': u}, t)
             u_.assign(u)

--- a/test/burgers.py
+++ b/test/burgers.py
@@ -16,7 +16,6 @@ from firedrake import *
 n = 32
 mesh = UnitSquareMesh(n, n, diagonal='left')
 fields = ['uv_2d']
-solves_per_dt = [1]
 end_time = 0.5
 dt = 1/n
 dt_per_export = 2

--- a/test/migrating_trench.py
+++ b/test/migrating_trench.py
@@ -53,9 +53,9 @@ def get_function_spaces(mesh):
                 get_functionspace(mesh, "DG", 1, name="H_2d"),
             ]),
         'sediment_2d':
-            get_functionspace(mesh, "DG", 1, name="H_2d"),
+            get_functionspace(mesh, "DG", 1, name="Q_2d"),
         'bathymetry_2d':
-            get_functionspace(mesh, "CG", 1),
+            get_functionspace(mesh, "CG", 1, name="P1_2d"),
     }
 
 

--- a/test/migrating_trench.py
+++ b/test/migrating_trench.py
@@ -19,7 +19,7 @@ are solved sequentially.
     Computers & Geosciences, 104658.
 """
 try:
-    import thetis
+    import thetis  # noqa
 except ImportError:
     import pytest
     pytest.xfail("Thetis is not installed")
@@ -94,8 +94,6 @@ def get_solver(self):
         options.timestep = dt
         options.simulation_export_time = dt*self.time_partition[i].timesteps_per_export
         options.simulation_end_time = t_end
-        if self.qoi_type == 'time_integrated' and np.isclose(t_end, end_time):
-            options.simulation_end_time += 0.5*dt
         options.horizontal_viscosity = Constant(1.0e-06)
         options.horizontal_diffusivity = Constant(0.15)
         options.nikuradse_bed_roughness = Constant(3*sed_options.average_sediment_size)

--- a/test/migrating_trench.py
+++ b/test/migrating_trench.py
@@ -32,7 +32,6 @@ nx, ny = lx*5, 5
 mesh = RectangleMesh(nx, ny, lx, ly)
 x, y = SpatialCoordinate(mesh)
 fields = ['swe2d', 'sediment', 'exner']
-solves_per_dt = [1, 1, 1]
 morfac = 300
 end_time = 0.75*3600/morfac
 dt = 0.3
@@ -93,7 +92,7 @@ def get_solver(self):
         options.timestepper_options.implicitness_theta = 1.0
         options.norm_smoother = Constant(0.1)
         options.timestep = dt
-        options.simulation_export_time = dt*self.time_partition[i].exports
+        options.simulation_export_time = dt*self.time_partition[i].timesteps_per_export
         options.simulation_end_time = t_end
         if self.qoi_type == 'time_integrated' and np.isclose(t_end, end_time):
             options.simulation_end_time += 0.5*dt

--- a/test/point_discharge2d.py
+++ b/test/point_discharge2d.py
@@ -279,4 +279,4 @@ if __name__ == "__main__":
         # Compute effectivity index
         Je = assemble(end_time_qoi({'tracer_2d': c})) - Jh
         I_eff = effectivity_index(eta, Je)
-        print(f"{J:11.4e}  {Jh:11.4e}  {I_eff:11.4e}")
+        pyrint(f"{J:11.4e}  {Jh:11.4e}  {I_eff:11.4e}")

--- a/test/point_discharge2d.py
+++ b/test/point_discharge2d.py
@@ -34,7 +34,6 @@ n = 0
 mesh = RectangleMesh(100*2**n, 20*2**n, 50, 10)
 fields = ['tracer_2d']
 function_space = {'tracer_2d': [FunctionSpace(mesh, "CG", 1)]}
-solves_per_dt = [1]
 end_time = 20.0
 dt = 20.0
 dt_per_export = 1

--- a/test/rossby_wave.py
+++ b/test/rossby_wave.py
@@ -19,7 +19,7 @@ backend.
     Oceans, 113(C7). (2008), pp. 3-6.
 """
 try:
-    import thetis
+    import thetis  # noqa
 except ImportError:
     import pytest
     pytest.xfail("Thetis is not installed")

--- a/test/rossby_wave.py
+++ b/test/rossby_wave.py
@@ -34,7 +34,6 @@ x, y = SpatialCoordinate(mesh)
 W = mesh.coordinates.function_space()
 mesh = Mesh(interpolate(as_vector([x-lx/2, y-ly/2]), W))
 fields = ['swe2d']
-solves_per_dt = [1]
 end_time = 20.0
 dt = 9.6/ny
 dt_per_export = int(10.0/dt)

--- a/test/solid_body_rotation.py
+++ b/test/solid_body_rotation.py
@@ -83,11 +83,11 @@ def get_solver(self):
             "sub_pc_type": "ilu",
         }
         prob1 = LinearVariationalProblem(a, L1, dq)
-        solv1 = LinearVariationalSolver(prob1, solver_parameters=sp)
+        solv1 = LinearVariationalSolver(prob1, solver_parameters=sp, options_prefix=field)
         prob2 = LinearVariationalProblem(a, L2, dq)
-        solv2 = LinearVariationalSolver(prob2, solver_parameters=sp)
+        solv2 = LinearVariationalSolver(prob2, solver_parameters=sp, options_prefix=field)
         prob3 = LinearVariationalProblem(a, L3, dq)
-        solv3 = LinearVariationalSolver(prob3, solver_parameters=sp)
+        solv3 = LinearVariationalSolver(prob3, solver_parameters=sp, options_prefix=field)
 
         # Time integrate from t_start to t_end
         t = t_start

--- a/test/solid_body_rotation.py
+++ b/test/solid_body_rotation.py
@@ -28,11 +28,10 @@ coords = mesh.coordinates.copy(deepcopy=True)
 coords.interpolate(coords - as_vector([0.5, 0.5]))
 mesh = Mesh(coords)
 fields = ['tracer_2d']
-solves_per_dt = [3]
 full_rotation = 2*pi
 end_time = full_rotation
 dt = pi/300
-dt_per_export = 75
+dt_per_export = 25
 
 
 def get_function_spaces(mesh):
@@ -83,9 +82,9 @@ def get_solver(self):
             "sub_pc_type": "ilu",
         }
         prob1 = LinearVariationalProblem(a, L1, dq)
-        solv1 = LinearVariationalSolver(prob1, solver_parameters=sp, options_prefix=field)
+        solv1 = LinearVariationalSolver(prob1, solver_parameters=sp)
         prob2 = LinearVariationalProblem(a, L2, dq)
-        solv2 = LinearVariationalSolver(prob2, solver_parameters=sp, options_prefix=field)
+        solv2 = LinearVariationalSolver(prob2, solver_parameters=sp)
         prob3 = LinearVariationalProblem(a, L3, dq)
         solv3 = LinearVariationalSolver(prob3, solver_parameters=sp, options_prefix=field)
 

--- a/test/solid_body_rotation_split.py
+++ b/test/solid_body_rotation_split.py
@@ -21,7 +21,7 @@ import solid_body_rotation as sbr
 
 
 fields = ['bell_2d', 'cone_2d', 'slot_cyl_2d']
-solves_per_dt = [3, 3, 3]
+end_time /= 3
 
 
 def get_function_spaces(mesh):

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -79,7 +79,6 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
     time_partition = TimePartition(
         end_time, 1, test_case.dt, test_case.fields,
         timesteps_per_export=test_case.dt_per_export,
-        solves_per_timestep=test_case.solves_per_dt,
     )
     mesh_seq = AdjointMeshSeq(
         time_partition, test_case.mesh, test_case.get_function_spaces,
@@ -100,7 +99,7 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
     adj_sols_expected = {}
     adj_values_expected = {}
     for field, fs in mesh_seq._fs.items():
-        solve_blocks = time_partition.get_solve_blocks(field)
+        solve_blocks = mesh_seq.get_solve_blocks(field)
         fwd_old_idx = mesh_seq.get_lagged_dependency_index(field, 0, solve_blocks)[0]
         adj_sols_expected[field] = solve_blocks[0].adj_sol.copy(deepcopy=True)
         adj_values_expected[field] = Function(
@@ -116,7 +115,6 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
         time_partition = TimePartition(
             end_time, N, test_case.dt, test_case.fields,
             timesteps_per_export=test_case.dt_per_export,
-            solves_per_timestep=test_case.solves_per_dt, debug=debug,
         )
         mesh_seq = AdjointMeshSeq(
             time_partition, test_case.mesh, test_case.get_function_spaces,

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -56,7 +56,7 @@ def qoi_type(request):
     return request.param
 
 
-def test_adjoint_same_mesh(problem, qoi_type, **kwargs):
+def test_adjoint_same_mesh(problem, qoi_type, debug=False):
     """
     Check that `solve_adjoint` gives the same
     result when applied on one or two subintervals.
@@ -116,14 +116,14 @@ def test_adjoint_same_mesh(problem, qoi_type, **kwargs):
         time_partition = TimePartition(
             end_time, N, test_case.dt, test_case.fields,
             timesteps_per_export=test_case.dt_per_export,
-            solves_per_timestep=test_case.solves_per_dt,
+            solves_per_timestep=test_case.solves_per_dt, debug=debug,
         )
         mesh_seq = AdjointMeshSeq(
             time_partition, test_case.mesh, test_case.get_function_spaces,
             test_case.get_initial_condition, test_case.get_solver,
             test_case.get_qoi, qoi_type=qoi_type,
         )
-        solutions = mesh_seq.solve_adjoint(get_adj_values=True, test_checkpoint_qoi=True, **kwargs)
+        solutions = mesh_seq.solve_adjoint(get_adj_values=True, test_checkpoint_qoi=True)
 
         # Check quantities of interest match
         assert np.isclose(J_expected, mesh_seq.J), f"QoIs do not match ({J_expected} vs." \

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -69,7 +69,7 @@ def test_adjoint_same_mesh(problem, qoi_type, **kwargs):
     from firedrake_adjoint import pyadjoint
 
     # Imports
-    print(f"\n--- Setting up {problem} test case with {qoi_type} QoI\n")
+    pyrint(f"\n--- Setting up {problem} test case with {qoi_type} QoI\n")
     test_case = importlib.import_module(problem)
     end_time = test_case.end_time
     if "solid_body_rotation" in problem:
@@ -88,7 +88,7 @@ def test_adjoint_same_mesh(problem, qoi_type, **kwargs):
     )
 
     # Solve forward and adjoint without solve_adjoint
-    print("\n--- Solving the adjoint problem on 1 subinterval using pyadjoint\n")
+    pyrint("\n--- Solving the adjoint problem on 1 subinterval using pyadjoint\n")
     ic = mesh_seq.initial_condition
     controls = [pyadjoint.Control(value) for key, value in ic.items()]
     sols = mesh_seq.solver(0, ic)
@@ -109,8 +109,8 @@ def test_adjoint_same_mesh(problem, qoi_type, **kwargs):
 
     # Loop over having one or two subintervals
     for N in range(1, 3):
-        print(f"\n--- Solving the adjoint problem on {N} subinterval"
-              + f"{'' if N == 1 else 's'} using pyroteus\n")
+        pyrint(f"\n--- Solving the adjoint problem on {N} subinterval"
+               + f"{'' if N == 1 else 's'} using pyroteus\n")
 
         # Solve forward and adjoint on each subinterval
         time_partition = TimePartition(
@@ -127,7 +127,7 @@ def test_adjoint_same_mesh(problem, qoi_type, **kwargs):
 
         # Check quantities of interest match
         assert np.isclose(J_expected, mesh_seq.J), f"QoIs do not match ({J_expected} vs." \
-                                                      + f"{mesh_seq.J})"
+                                                   + f"{mesh_seq.J})"
 
         # Check adjoint solutions at initial time match
         for field in time_partition.fields:

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -68,6 +68,10 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
     import importlib
     from firedrake_adjoint import pyadjoint
 
+    # Debugging
+    if debug:
+        set_log_level(DEBUG)
+
     # Imports
     pyrint(f"\n--- Setting up {problem} test case with {qoi_type} QoI\n")
     test_case = importlib.import_module(problem)
@@ -150,4 +154,4 @@ def test_adjoint_same_mesh_parallel(problem, qoi_type):
 
 
 if __name__ == "__main__":
-    test_adjoint_same_mesh("migrating_trench", "end_time", debug=True)
+    test_adjoint_same_mesh("burgers", "end_time", debug=True)

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -56,7 +56,7 @@ def qoi_type(request):
     return request.param
 
 
-def test_adjoint_same_mesh(problem, qoi_type):
+def test_adjoint_same_mesh(problem, qoi_type, **kwargs):
     """
     Check that `solve_adjoint` gives the same
     result when applied on one or two subintervals.
@@ -123,7 +123,7 @@ def test_adjoint_same_mesh(problem, qoi_type):
             test_case.get_initial_condition, test_case.get_solver,
             test_case.get_qoi, qoi_type=qoi_type,
         )
-        solutions = mesh_seq.solve_adjoint(get_adj_values=True, test_checkpoint_qoi=True)
+        solutions = mesh_seq.solve_adjoint(get_adj_values=True, test_checkpoint_qoi=True, **kwargs)
 
         # Check quantities of interest match
         assert np.isclose(J_expected, mesh_seq.J), f"QoIs do not match ({J_expected} vs." \
@@ -152,4 +152,4 @@ def test_adjoint_same_mesh_parallel(problem, qoi_type):
 
 
 if __name__ == "__main__":
-    test_adjoint_same_mesh("migrating_trench", "end_time")
+    test_adjoint_same_mesh("migrating_trench", "end_time", debug=True)


### PR DESCRIPTION
Extract solve blocks using options prefixes. This avoids indexing tedium and needing to provide `solves_per_timestep` .

This PR also provides logging functionality and fixes the migrating trench test case.