### PR TITLE
Python implementations of mesh quality

### DIFF
--- a/pyroteus/mesh_quality.py
+++ b/pyroteus/mesh_quality.py
@@ -153,14 +153,14 @@ def get_scaled_jacobians2d(mesh, python=False):
     return scaled_jacobians
 
 
-def get_quality_metrics2d(mesh, M, python=False):
+def get_quality_metrics2d(mesh, metric, python=False):
     """
-    Given a matrix M, a linear function in 2 dimensions, this function
+    Given a Riemannian metric, M, this function
     outputs the value of the Quality metric Q_M based on the
     transformation encoded in M.
 
     :arg mesh: the input mesh to do computations on
-    :arg M: the (2 x 2) matrix representing the metric space transformation
+    :arg M: the (2 x 2) matrix field representing the metric space transformation
     :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function metrics with metric data.
@@ -169,15 +169,13 @@ def get_quality_metrics2d(mesh, M, python=False):
     if python:
         raise NotImplementedError
     else:
-        P1_ten = TensorFunctionSpace(mesh, "CG", 1)
         coords = mesh.coordinates
-        tensor = interpolate(as_matrix(M), P1_ten)
-        metrics = Function(P0)
+        quality = Function(P0)
         kernel = eigen_kernel(get_metric2d)
-        op2.par_loop(kernel, mesh.cell_set, metrics.dat(op2.WRITE, metrics.cell_node_map()),
-                     tensor.dat(op2.READ, tensor.cell_node_map()),
+        op2.par_loop(kernel, mesh.cell_set, quality.dat(op2.WRITE, quality.cell_node_map()),
+                     metric.dat(op2.READ, metric.cell_node_map()),
                      coords.dat(op2.READ, coords.cell_node_map()))
-    return metrics
+    return quality
 
 
 if __name__ == "__main__":

--- a/pyroteus/mesh_quality.py
+++ b/pyroteus/mesh_quality.py
@@ -1,133 +1,191 @@
-from .kernel import *
+from pyroteus.kernel import *
 from firedrake import *
 
 
-def get_min_angles2d(mesh):
+def get_min_angles2d(mesh, python=False):
     """
     Computes the minimum angle of each cell in a 2D triangular mesh
 
-    :param mesh: the input mesh to do computations on
+    :arg mesh: the input mesh to do computations on
+    :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function min_angles with
     minimum angle data
     """
     P0 = FunctionSpace(mesh, "DG", 0)
-    coords = mesh.coordinates
-    min_angles = Function(P0)
-    kernel = eigen_kernel(get_min_angle2d)
-    op2.par_loop(kernel, mesh.cell_set, min_angles.dat(op2.WRITE, min_angles.cell_node_map()),
-                 coords.dat(op2.READ, coords.cell_node_map()))
+    if python:
+        raise NotImplementedError
+    else:
+        coords = mesh.coordinates
+        min_angles = Function(P0)
+        kernel = eigen_kernel(get_min_angle2d)
+        op2.par_loop(kernel, mesh.cell_set, min_angles.dat(op2.WRITE, min_angles.cell_node_map()),
+                     coords.dat(op2.READ, coords.cell_node_map()))
     return min_angles
 
 
-def get_areas2d(mesh):
+def get_areas2d(mesh, python=False):
     """
     Computes the area of each cell in a 2D triangular mesh
 
-    :param mesh: the input mesh to do computations on
+    :arg mesh: the input mesh to do computations on
+    :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function areas with
     area data
     """
     P0 = FunctionSpace(mesh, "DG", 0)
-    coords = mesh.coordinates
-    areas = Function(P0)
-    kernel = eigen_kernel(get_area2d)
-    op2.par_loop(kernel, mesh.cell_set, areas.dat(op2.WRITE, areas.cell_node_map()),
-                 coords.dat(op2.READ, coords.cell_node_map()))
+    if python:
+        areas = interpolate(CellVolume(mesh), P0)
+    else:
+        coords = mesh.coordinates
+        areas = Function(P0)
+        kernel = eigen_kernel(get_area2d)
+        op2.par_loop(kernel, mesh.cell_set, areas.dat(op2.WRITE, areas.cell_node_map()),
+                     coords.dat(op2.READ, coords.cell_node_map()))
     return areas
 
 
-def get_aspect_ratios2d(mesh):
+def get_aspect_ratios2d(mesh, python=False):
     """
     Computes the aspect ratio of each cell in a 2D triangular mesh
 
-    :param mesh: the input mesh to do computations on
+    :arg mesh: the input mesh to do computations on
+    :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function aspect_ratios with
     aspect ratio data
     """
     P0 = FunctionSpace(mesh, "DG", 0)
-    coords = mesh.coordinates
-    aspect_ratios = Function(P0)
-    kernel = eigen_kernel(get_aspect_ratio2d)
-    op2.par_loop(kernel, mesh.cell_set, aspect_ratios.dat(op2.WRITE, aspect_ratios.cell_node_map()),
-                 coords.dat(op2.READ, coords.cell_node_map()))
+    if python:
+        P0_ten = TensorFunctionSpace(mesh, "DG", 0)
+        J = interpolate(Jacobian(mesh), P0_ten)
+        edge1 = as_vector([J[0, 0], J[1, 0]])
+        edge2 = as_vector([J[0, 1], J[1, 1]])
+        edge3 = edge1 - edge2
+        a = sqrt(dot(edge1, edge1))
+        b = sqrt(dot(edge2, edge2))
+        c = sqrt(dot(edge3, edge3))
+        aspect_ratios = interpolate(a*b*c/((a+b-c)*(b+c-a)*(c+a-b)), P0)
+    else:
+        coords = mesh.coordinates
+        aspect_ratios = Function(P0)
+        kernel = eigen_kernel(get_aspect_ratio2d)
+        op2.par_loop(kernel, mesh.cell_set, aspect_ratios.dat(op2.WRITE, aspect_ratios.cell_node_map()),
+                     coords.dat(op2.READ, coords.cell_node_map()))
     return aspect_ratios
 
 
-def get_eskews2d(mesh):
+def get_eskews2d(mesh, python=False):
     """
     Computes the equiangle skew of each cell in a 2D triangular mesh
 
-    :param mesh: the input mesh to do computations on
+    :arg mesh: the input mesh to do computations on
+    :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function eskews with equiangle skew
     data.
     """
     P0 = FunctionSpace(mesh, "DG", 0)
-    coords = mesh.coordinates
-    eskews = Function(P0)
-    kernel = eigen_kernel(get_eskew2d)
-    op2.par_loop(kernel, mesh.cell_set, eskews.dat(op2.WRITE, eskews.cell_node_map()),
-                 coords.dat(op2.READ, coords.cell_node_map()))
+    if python:
+        raise NotImplementedError
+    else:
+        coords = mesh.coordinates
+        eskews = Function(P0)
+        kernel = eigen_kernel(get_eskew2d)
+        op2.par_loop(kernel, mesh.cell_set, eskews.dat(op2.WRITE, eskews.cell_node_map()),
+                     coords.dat(op2.READ, coords.cell_node_map()))
     return eskews
 
 
-def get_skewnesses2d(mesh):
+def get_skewnesses2d(mesh, python=False):
     """
     Computes the skewness of each cell in a 2D triangular mesh
 
-    :param mesh: the input mesh to do computations on
+    :arg mesh: the input mesh to do computations on
+    :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function skews with skewness
     data.
     """
     P0 = FunctionSpace(mesh, "DG", 0)
-    coords = mesh.coordinates
-    skews = Function(P0)
-    kernel = eigen_kernel(get_skewness2d)
-    op2.par_loop(kernel, mesh.cell_set, skews.dat(op2.WRITE, skews.cell_node_map()),
-                 coords.dat(op2.READ, coords.cell_node_map()))
+    if python:
+        raise NotImplementedError
+    else:
+        coords = mesh.coordinates
+        skews = Function(P0)
+        kernel = eigen_kernel(get_skewness2d)
+        op2.par_loop(kernel, mesh.cell_set, skews.dat(op2.WRITE, skews.cell_node_map()),
+                     coords.dat(op2.READ, coords.cell_node_map()))
     return skews
 
 
-def get_scaled_jacobians2d(mesh):
+def get_scaled_jacobians2d(mesh, python=False):
     """
     Computes the scaled Jacobian of each cell in a 2D triangular mesh
 
-    :param mesh: the input mesh to do computations on
+    :arg mesh: the input mesh to do computations on
+    :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function scaled_jacobians with scaled
     jacobian data.
     """
     P0 = FunctionSpace(mesh, "DG", 0)
-    coords = mesh.coordinates
-    scaled_jacobians = Function(P0)
-    kernel = eigen_kernel(get_scaled_jacobian2d)
-    op2.par_loop(kernel, mesh.cell_set, scaled_jacobians.dat(op2.WRITE, scaled_jacobians.cell_node_map()),
-                 coords.dat(op2.READ, coords.cell_node_map()))
+    if python:
+        P0_ten = TensorFunctionSpace(mesh, "DG", 0)
+        J = interpolate(Jacobian(mesh), P0_ten)
+        edge1 = as_vector([J[0, 0], J[1, 0]])
+        edge2 = as_vector([J[0, 1], J[1, 1]])
+        edge3 = edge1 - edge2
+        a = sqrt(dot(edge1, edge1))
+        b = sqrt(dot(edge2, edge2))
+        c = sqrt(dot(edge3, edge3))
+        detJ = JacobianDeterminant(mesh)
+        jacobian_sign = sign(detJ)
+        max_product = Max(Max(Max(a*b, a*c), Max(b*c, b*a)), Max(c*a, c*b))
+        scaled_jacobians = interpolate(detJ/max_product*jacobian_sign, P0)
+    else:
+        coords = mesh.coordinates
+        scaled_jacobians = Function(P0)
+        kernel = eigen_kernel(get_scaled_jacobian2d)
+        op2.par_loop(kernel, mesh.cell_set, scaled_jacobians.dat(op2.WRITE, scaled_jacobians.cell_node_map()),
+                     coords.dat(op2.READ, coords.cell_node_map()))
     return scaled_jacobians
 
 
-def get_quality_metrics2d(mesh, M):
+def get_quality_metrics2d(mesh, M, python=False):
     """
     Given a matrix M, a linear function in 2 dimensions, this function
     outputs the value of the Quality metric Q_M based on the
     transformation encoded in M.
 
-    :param mesh: the input mesh to do computations on
-    :param M: the (2 x 2) matrix representing the metric space transformation
+    :arg mesh: the input mesh to do computations on
+    :arg M: the (2 x 2) matrix representing the metric space transformation
+    :kwarg python: compute the measure using Python?
 
     :rtype: firedrake.function.Function metrics with metric data.
     """
     P0 = FunctionSpace(mesh, "DG", 0)
-    P1_ten = TensorFunctionSpace(mesh, "CG", 1)
-    coords = mesh.coordinates
-    tensor = interpolate(as_matrix(M), P1_ten)
-    metrics = Function(P0)
-    kernel = eigen_kernel(get_metric2d)
-    op2.par_loop(kernel, mesh.cell_set, metrics.dat(op2.WRITE, metrics.cell_node_map()),
-                 tensor.dat(op2.READ, tensor.cell_node_map()),
-                 coords.dat(op2.READ, coords.cell_node_map()))
+    if python:
+        raise NotImplementedError
+    else:
+        P1_ten = TensorFunctionSpace(mesh, "CG", 1)
+        coords = mesh.coordinates
+        tensor = interpolate(as_matrix(M), P1_ten)
+        metrics = Function(P0)
+        kernel = eigen_kernel(get_metric2d)
+        op2.par_loop(kernel, mesh.cell_set, metrics.dat(op2.WRITE, metrics.cell_node_map()),
+                     tensor.dat(op2.READ, tensor.cell_node_map()),
+                     coords.dat(op2.READ, coords.cell_node_map()))
     return metrics
+
+
+if __name__ == "__main__":
+    mesh = UnitSquareMesh(4, 4)
+    mesh.coordinates.dat.data[:] += np.random.rand(*mesh.coordinates.dat.data.shape)
+    f = get_aspect_ratios2d
+    q = np.array(f(mesh).dat.data, dtype=float)
+    qp = np.array(f(mesh, python=True).dat.data, dtype=float)
+    print(q)
+    print(qp)
+    print(np.allclose(q, qp))

--- a/pyroteus/mesh_quality.py
+++ b/pyroteus/mesh_quality.py
@@ -176,14 +176,3 @@ def get_quality_metrics2d(mesh, metric, python=False):
                      metric.dat(op2.READ, metric.cell_node_map()),
                      coords.dat(op2.READ, coords.cell_node_map()))
     return quality
-
-
-if __name__ == "__main__":
-    mesh = UnitSquareMesh(4, 4)
-    mesh.coordinates.dat.data[:] += np.random.rand(*mesh.coordinates.dat.data.shape)
-    f = get_aspect_ratios2d
-    q = np.array(f(mesh).dat.data, dtype=float)
-    qp = np.array(f(mesh, python=True).dat.data, dtype=float)
-    print(q)
-    print(qp)
-    print(np.allclose(q, qp))

--- a/pyroteus/utility.py
+++ b/pyroteus/utility.py
@@ -2,8 +2,8 @@
 Utility functions and classes for mesh adaptation.
 """
 from __future__ import absolute_import
+from pyroteus.mesh_quality import *
 import firedrake
-from firedrake import *
 from .log import *
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -19,17 +19,10 @@ def Mesh(arg, **kwargs):
         * cell size;
         * facet area.
 
-    Extra quantities can be computed using the flags:
-        * ``compute_aspect_ratio``;
-        * ``compute_scaled_jacobian``.
-
     The argument and keyword arguments are passed to
     Firedrake's ``Mesh`` constructor, modified so
     that the argument could also be a mesh.
     """
-    ar = kwargs.pop('compute_aspect_ratio', False)
-    sj = kwargs.pop('compute_scaled_jacobian', False)
-    extras = ar or sj
     try:
         mesh = firedrake.Mesh(arg, **kwargs)
     except TypeError:
@@ -46,32 +39,9 @@ def Mesh(arg, **kwargs):
     else:
         mesh.boundary_area = OrderedDict({i: assemble(one*ds(int(i))) for i in boundary_markers})
 
-    # Compute aspect ratio and scaled Jacobian
+    # Cell size
     if dim == 2 and mesh.coordinates.ufl_element().cell() == triangle:
-
-        # Cell size
         mesh.delta_x = interpolate(CellSize(mesh), P0)
-
-        if extras:
-            P0_ten = TensorFunctionSpace(mesh, "DG", 0)
-            J = interpolate(Jacobian(mesh), P0_ten)
-            edge1 = as_vector([J[0, 0], J[1, 0]])
-            edge2 = as_vector([J[0, 1], J[1, 1]])
-            edge3 = edge1 - edge2
-            a = sqrt(dot(edge1, edge1))
-            b = sqrt(dot(edge2, edge2))
-            c = sqrt(dot(edge3, edge3))
-
-            # Aspect ratio
-            if ar:
-                mesh.aspect_ratio = interpolate(a*b*c/((a+b-c)*(b+c-a)*(c+a-b)), P0)
-
-            # Scaled Jacobian
-            if sj:
-                detJ = JacobianDeterminant(mesh)
-                jacobian_sign = sign(detJ)
-                max_product = Max(Max(Max(a*b, a*c), Max(b*c, b*a)), Max(c*a, c*b))
-                mesh.scaled_jacobian = interpolate(detJ/max_product*jacobian_sign, P0)
 
     return mesh
 

--- a/test/test_meshquality.py
+++ b/test/test_meshquality.py
@@ -22,20 +22,47 @@ import pytest
                             "skewness_2d",
                             "quality_metric_2d",
                          ])
-def test_uniform_quality(measure, expected):
+def test_uniform_quality_2d(measure, expected):
     """
     Check that the computation of each quality measure
     gives the expected value for a uniform (isotropic)
     2D triangular mesh.
     """
+    measure = getattr(mq, measure)
     mesh = UnitSquareMesh(10, 10)
     if measure == "get_quality_metrics2d":
         P1_ten = TensorFunctionSpace(mesh, "CG", 1)
         M = interpolate(Identity(2), P1_ten)
-        q = getattr(mq, measure)(mesh, M)
+        q = measure(mesh, M)
     else:
-        q = getattr(mq, measure)(mesh)
+        q = measure(mesh)
     true_vals = np.array([expected for _ in q.dat.data])
     assert np.allclose(true_vals, q.dat.data)
     if measure == "get_areas2d":
         assert np.isclose(sum(q.dat.data), 1)
+
+
+@pytest.mark.parametrize("measure",
+                         [
+                            ("get_areas2d"),
+                            ("get_aspect_ratios2d"),
+                            ("get_scaled_jacobians2d"),
+                         ],
+                         ids=[
+                            "area_2d",
+                            "aspect_ratio_2d",
+                            "scaled_jacobian_2d",
+                         ])
+def test_consistency_2d(measure):
+    """
+    Check that the C++ and Python implementations of the
+    quality measures are consistent for a non-uniform
+    2D triangular mesh.
+    """
+    np.random.seed(0)
+    measure = getattr(mq, measure)
+    mesh = UnitSquareMesh(4, 4)
+    mesh.coordinates.dat.data[:] += np.random.rand(*mesh.coordinates.dat.data.shape)
+    quality_cpp = measure(mesh)
+    quality_py = measure(mesh, python=True)
+    assert np.allclose(quality_cpp.dat.data, quality_py.dat.data)

--- a/test/test_meshquality.py
+++ b/test/test_meshquality.py
@@ -3,97 +3,39 @@ import pyroteus.mesh_quality as mq
 import pytest
 
 
-@pytest.fixture
-def include_dirs():
-    try:
-        from firedrake.slate.slac.compiler import PETSC_ARCH
-    except ImportError:
-        import os
-        PETSC_ARCH = os.path.join(os.environ.get('PETSC_DIR'), os.environ.get('PETSC_ARCH'))
-    return ["%s/include/eigen3" % PETSC_ARCH]
-
-
-def test_min_angle2d(include_dirs):
+@pytest.mark.parametrize("measure,expected",
+                         [
+                            ("get_min_angles2d", np.pi/4),
+                            ("get_areas2d", 0.005),
+                            ("get_eskews2d", 1.070796),
+                            ("get_aspect_ratios2d", 1.207107),
+                            ("get_scaled_jacobians2d", 0.707107),
+                            ("get_skewnesses2d", 0.463648),
+                            ("get_quality_metrics2d", 6.928203),
+                         ],
+                         ids=[
+                            "minimum_angle_2d",
+                            "area_2d",
+                            "equiangle_skew_2d",
+                            "aspect_ratio_2d",
+                            "scaled_jacobian_2d",
+                            "skewness_2d",
+                            "quality_metric_2d",
+                         ])
+def test_uniform_quality(measure, expected):
     """
-    Check computation of minimum angle for a 2D triangular mesh.
-    For a uniform (isotropic) mesh, the minimum angle should be
-    pi/4 for each cell.
-    """
-    mesh = UnitSquareMesh(10, 10)
-    min_angles = mq.get_min_angles2d(mesh)
-    true_vals = np.array([np.pi / 4 for _ in min_angles.dat.data])
-    assert np.allclose(true_vals, min_angles.dat.data)
-
-
-def test_area2d(include_dirs):
-    """
-    Check computation of areas for a 2D triangular mesh.
-    Sum of areas of all cells should equal 1 on a UnitSquareMesh.
-    Areas of all cells must also be equal.
+    Check that the computation of each quality measure
+    gives the expected value for a uniform (isotropic)
+    2D triangular mesh.
     """
     mesh = UnitSquareMesh(10, 10)
-    areas = mq.get_areas2d(mesh)
-    true_vals = np.array([0.005 for _ in areas.dat.data])
-    assert np.allclose(true_vals, areas.dat.data)
-    assert (np.isclose(sum(areas.dat.data), 1))
-
-
-def test_eskew2d(include_dirs):
-    """
-    Check computation of equiangle skew for a 2D triangular mesh.
-    For a uniform (isotropic) mesh, the equiangle skew should be
-    equal for all elements.
-    """
-    mesh = UnitSquareMesh(10, 10)
-    eskews = mq.get_eskews2d(mesh)
-    true_vals = np.array([1.070796 for _ in eskews.dat.data])
-    assert np.allclose(true_vals, eskews.dat.data)
-
-
-def test_aspect_ratio2d(include_dirs):
-    """
-    Check computation of aspect ratio for a 2D triangular mesh.
-    For a uniform (isotropic) mesh, the aspect ratio should be
-    equal for all elements.
-    """
-    mesh = UnitSquareMesh(10, 10)
-    aspect_ratios = mq.get_aspect_ratios2d(mesh)
-    true_vals = np.array([1.207107 for _ in aspect_ratios.dat.data])
-    assert np.allclose(true_vals, aspect_ratios.dat.data)
-
-
-def test_scaled_jacobian2d(include_dirs):
-    """
-    Check computation of scaled Jacobian for a 2D triangular mesh.
-    For a uniform (isotropic) mesh, the scaled Jacobian should be
-    equal for all elements.
-    """
-    mesh = UnitSquareMesh(10, 10)
-    scaled_jacobians = mq.get_scaled_jacobians2d(mesh)
-    true_vals = np.array([0.707107 for _ in scaled_jacobians.dat.data])
-    assert np.allclose(true_vals, scaled_jacobians.dat.data)
-
-
-def test_skewness2d(include_dirs):
-    """
-    Check computation of skewness for a 2D triangular mesh.
-    For a uniform (isotropic) mesh, the skewness should be
-    equal for all elements.
-    """
-    mesh = UnitSquareMesh(10, 10)
-    skewnesses = mq.get_skewnesses2d(mesh)
-    true_vals = np.array([0.463648 for _ in skewnesses.dat.data])
-    assert np.allclose(true_vals, skewnesses.dat.data)
-
-
-def test_metric2d(include_dirs):
-    """
-    Check computation of skewness for a 2D triangular mesh.
-    For a uniform (isotropic) mesh, the skewness should be
-    equal for all elements.
-    """
-    mesh = UnitSquareMesh(10, 10)
-    M = [[1, 0], [0, 1]]
-    metrics = mq.get_quality_metrics2d(mesh, M)
-    true_vals = np.array([6.928203 for _ in metrics.dat.data])
-    assert np.allclose(true_vals, metrics.dat.data)
+    if measure == "get_quality_metrics2d":
+        P1_ten = TensorFunctionSpace(mesh, "CG", 1)
+        M = interpolate(Identity(2), P1_ten)
+        q = getattr(mq, measure)(mesh, M)
+    else:
+        q = getattr(mq, measure)(mesh)
+    true_vals = np.array([expected for _ in q.dat.data])
+    assert np.allclose(true_vals, q.dat.data)
+    if measure == "get_areas2d":
+        assert np.isclose(sum(q.dat.data), 1)


### PR DESCRIPTION
There were high-level implementations of aspect ratio and scaled Jacobian lying around, so I moved them into the new `mesh_quality.py` file and gave each quality measure an optional `python` kwarg.

Other notes:
* I condensed the 2D mesh quality tests into one using `pytest.mark.parametrize`.
* I made the metric quality measure take a metric `Function` as input, rather than a fixed matrix.
* I switched from `:param:` to `:arg:`/`:kwarg:` to be consistent with the rest of the code.