### PR TITLE
Streamline object-oriented approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pyroteus.egg-info/
 docs/source/pyroteus.rst
 
 # File extensions
+*.ipynb*
 *.jpg
 *.msh
 *.pdf

--- a/demos/burgers-oo.py
+++ b/demos/burgers-oo.py
@@ -1,0 +1,109 @@
+# Object-oriented Burgers equation
+# ================================
+
+# You may have noticed that the functions `get_form`, `get_solver`,
+# `get_initial_condition` and `get_qoi` all take a :class:`MeshSeq`
+# as input and return a function. If this all feels a lot like
+# writing methods for a :class:`MeshSeq` subclass, that's because
+# this is exactly what we are doing. The constructors for
+# :class:`MeshSeq` and :class:`AdjointMeshSeq` simply take these
+# functions and adopt them as methods. A more natural way to write
+# the subclass yourself.
+#
+# In the following, we mostly copy the contents from the previous
+# demos and combine the methods into a subclass called
+# :class:`BurgersMeshSeq`. The main difference to note is that
+# `get_qoi` should named as :meth:`get_qoi_function`. This is
+# because it gets modified internally to account for annotation.
+# ::
+
+from firedrake import *
+from pyroteus_adjoint import *
+
+
+class BurgersMeshSeq(AdjointMeshSeq):
+    def get_function_spaces(self, mesh):
+        return {"u": VectorFunctionSpace(mesh, "CG", 2)}
+
+    def get_form(self):
+        def form(index, solutions):
+            u, u_ = solutions["u"]
+            P = self.time_partition
+            dt = Constant(P.timesteps[index])
+
+            # Specify viscosity coefficient
+            nu = Constant(0.0001)
+
+            # Setup variational problem
+            v = TestFunction(u.function_space())
+            F = (
+                inner((u - u_) / dt, v) * dx
+                + inner(dot(u, nabla_grad(u)), v) * dx
+                + nu * inner(grad(u), grad(v)) * dx
+            )
+            return F
+
+        return form
+
+    def get_solver(self):
+        def solver(index, ic):
+            function_space = self.function_spaces["u"][index]
+            u = Function(function_space)
+
+            # Initialise 'lagged' solution
+            u_ = Function(function_space, name="u_old")
+            u_.assign(ic["u"])
+
+            # Define form
+            F = self.form(index, {"u": (u, u_)})
+
+            # Time integrate from t_start to t_end
+            P = self.time_partition
+            t_start, t_end = P.subintervals[index]
+            dt = P.timesteps[index]
+            t = t_start
+            while t < t_end - 1.0e-05:
+                solve(F == 0, u, ad_block_tag="u")
+                u_.assign(u)
+                t += dt
+            return {"u": u}
+
+        return solver
+
+    def get_initial_condition(self):
+        fs = self.function_spaces["u"][0]
+        x, y = SpatialCoordinate(self[0])
+        return {"u": interpolate(as_vector([sin(pi * x), 0]), fs)}
+
+    def get_qoi_function(self, solutions, i):
+        def end_time_qoi():
+            u = solutions["u"]
+            return inner(u, u) * ds(2)
+
+        return end_time_qoi
+
+
+# We apply exactly the same setup as before, except that the :class:`BurgersMeshSeq`
+# class is used. ::
+
+n = 32
+meshes = [UnitSquareMesh(n, n, diagonal="left"), UnitSquareMesh(n, n, diagonal="left")]
+end_time = 0.5
+dt = 1 / n
+num_subintervals = 2
+P = TimePartition(
+    end_time, num_subintervals, dt, "u", timesteps_per_export=2, debug=True
+)
+mesh_seq = BurgersMeshSeq(P, meshes, qoi_type="end_time")
+solutions = mesh_seq.solve_adjoint()
+
+# Plotting this, we find that the results are identical to those generated previously. ::
+
+fig, axes = plot_snapshots(solutions, P, "u", "adjoint", levels=np.linspace(0, 0.8, 9))
+fig.savefig("burgers-oo.jpg")
+
+# .. figure:: burgers-oo.jpg
+#    :figwidth: 90%
+#    :align: center
+#
+# This demo can also be accessed as a `Python script <burgers-oo.py>`__.

--- a/demos/burgers-time_integrated.py
+++ b/demos/burgers-time_integrated.py
@@ -111,4 +111,8 @@ fig.savefig("burgers-time_integrated.jpg")
 # has a source term at the right hand boundary, rather
 # than a instantaneous pulse at the terminal time.
 #
+# In the `next demo <./burgers-oo.py.html>`__, we solve
+# the Burgers problem one last time, but using an
+# object-oriented approach.
+#
 # This demo can also be accessed as a `Python script <burgers-time_integrated.py>`__.

--- a/demos/burgers-time_integrated.py
+++ b/demos/burgers-time_integrated.py
@@ -26,6 +26,7 @@ def get_solver(mesh_seq):
     def solver(index, ic):
         function_space = mesh_seq.function_spaces["u"][index]
         u = Function(function_space, name="u")
+        solution_map = {"u": u}
 
         # Initialise 'lagged' solution
         u_ = Function(function_space, name="u_old")
@@ -38,13 +39,13 @@ def get_solver(mesh_seq):
         t_start, t_end = mesh_seq.subintervals[index]
         dt = mesh_seq.time_partition.timesteps[index]
         t = t_start
-        qoi = mesh_seq.get_qoi(index)
+        qoi = mesh_seq.get_qoi(solution_map, index)
         while t < t_end - 1.0e-05:
             solve(F == 0, u, ad_block_tag="u")
-            mesh_seq.J += qoi({"u": u}, t)
+            mesh_seq.J += qoi(t)
             u_.assign(u)
             t += dt
-        return {"u": u}
+        return solution_map
 
     return solver
 
@@ -62,11 +63,11 @@ def get_solver(mesh_seq):
 # recompilation if the value is changed. ::
 
 
-def get_qoi(mesh_seq, i):
+def get_qoi(mesh_seq, solutions, i):
     dtc = Constant(mesh_seq.time_partition[i].timestep)
 
-    def time_integrated_qoi(sol, t):
-        u = sol["u"]
+    def time_integrated_qoi(t):
+        u = solutions["u"]
         return dtc * inner(u, u) * ds(2)
 
     return time_integrated_qoi
@@ -82,22 +83,24 @@ end_time = 0.5
 dt = 1 / n
 
 num_subintervals = 2
-P = TimePartition(end_time, num_subintervals, dt, fields, timesteps_per_export=2)
+time_partition = TimePartition(
+    end_time, num_subintervals, dt, fields, timesteps_per_export=2
+)
 mesh_seq = AdjointMeshSeq(
-    P,
+    time_partition,
     meshes,
-    get_function_spaces,
-    get_initial_condition,
-    get_form,
-    get_solver,
-    get_qoi,
+    get_function_spaces=get_function_spaces,
+    get_initial_condition=get_initial_condition,
+    get_form=get_form,
+    get_solver=get_solver,
+    get_qoi=get_qoi,
     qoi_type="time_integrated",
 )
 solutions = mesh_seq.solve_adjoint()
 
 # Finally, plot snapshots of the adjoint solution. ::
 
-fig, axes = plot_snapshots(solutions, P, "u", "adjoint")
+fig, axes = plot_snapshots(solutions, time_partition, "u", "adjoint")
 fig.savefig("burgers-time_integrated.jpg")
 
 # .. figure:: burgers-time_integrated.jpg

--- a/demos/burgers.py
+++ b/demos/burgers.py
@@ -147,7 +147,7 @@ dt = 1 / n
 # subintervals. ::
 
 num_subintervals = 2
-P = TimePartition(
+time_partition = TimePartition(
     end_time,
     num_subintervals,
     dt,
@@ -159,7 +159,12 @@ P = TimePartition(
 # solve Burgers equation over the meshes in sequence. ::
 
 mesh_seq = MeshSeq(
-    P, meshes, get_function_spaces, get_initial_condition, get_form, get_solver
+    time_partition,
+    meshes,
+    get_function_spaces=get_function_spaces,
+    get_initial_condition=get_initial_condition,
+    get_form=get_form,
+    get_solver=get_solver,
 )
 solutions = mesh_seq.solve_forward()
 
@@ -167,7 +172,9 @@ solutions = mesh_seq.solve_forward()
 # looping over ``solutions['forward']``. This can be achieved using
 # the plotting driver function ``plot_snapshots``.
 
-fig, axes = plot_snapshots(solutions, P, "u", "forward", levels=np.linspace(0, 1, 9))
+fig, axes = plot_snapshots(
+    solutions, time_partition, "u", "forward", levels=np.linspace(0, 1, 9)
+)
 fig.savefig("burgers.jpg")
 
 # .. figure:: burgers.jpg

--- a/demos/burgers1.py
+++ b/demos/burgers1.py
@@ -39,8 +39,8 @@ from burgers import (
 # hand boundary. ::
 
 
-def get_qoi(mesh_seq, i):
-    def end_time_qoi(solutions):
+def get_qoi(mesh_seq, solutions, i):
+    def end_time_qoi():
         u = solutions["u"]
         return inner(u, u) * ds(2)
 
@@ -60,7 +60,7 @@ dt = 1 / n
 # single mesh, so the partition is trivial and we can use the
 # :class:`TimeInterval` constructor. ::
 
-P = TimeInterval(end_time, dt, fields, timesteps_per_export=2)
+time_partition = TimeInterval(end_time, dt, fields, timesteps_per_export=2)
 
 # Finally, we are able to construct an :class:`AdjointMeshSeq` and
 # thereby call its :attr:`solve_adjoint` method. This computes the QoI
@@ -73,13 +73,13 @@ P = TimeInterval(end_time, dt, fields, timesteps_per_export=2)
 # the adjoint solution at the next timestep, respectively. ::
 
 mesh_seq = AdjointMeshSeq(
-    P,
+    time_partition,
     mesh,
-    get_function_spaces,
-    get_initial_condition,
-    get_form,
-    get_solver,
-    get_qoi,
+    get_function_spaces=get_function_spaces,
+    get_initial_condition=get_initial_condition,
+    get_form=get_form,
+    get_solver=get_solver,
+    get_qoi=get_qoi,
     qoi_type="end_time",
 )
 solutions = mesh_seq.solve_adjoint()
@@ -88,7 +88,9 @@ solutions = mesh_seq.solve_adjoint()
 # looping over ``solutions['adjoint']``. This can also be achieved using
 # the plotting driver function ``plot_snapshots``.
 
-fig, axes = plot_snapshots(solutions, P, "u", "adjoint", levels=np.linspace(0, 0.8, 9))
+fig, axes = plot_snapshots(
+    solutions, time_partition, "u", "adjoint", levels=np.linspace(0, 0.8, 9)
+)
 fig.savefig("burgers1-end_time.jpg")
 
 # .. figure:: burgers1-end_time.jpg

--- a/demos/burgers2.py
+++ b/demos/burgers2.py
@@ -36,24 +36,26 @@ dt = 1 / n
 # associated with the two function spaces. ::
 
 num_subintervals = 2
-P = TimePartition(
+time_partition = TimePartition(
     end_time, num_subintervals, dt, fields, timesteps_per_export=2, debug=True
 )
 mesh_seq = AdjointMeshSeq(
-    P,
+    time_partition,
     meshes,
-    get_function_spaces,
-    get_initial_condition,
-    get_form,
-    get_solver,
-    get_qoi,
+    get_function_spaces=get_function_spaces,
+    get_initial_condition=get_initial_condition,
+    get_form=get_form,
+    get_solver=get_solver,
+    get_qoi=get_qoi,
     qoi_type="end_time",
 )
 solutions = mesh_seq.solve_adjoint()
 
 # Finally, plot snapshots of the adjoint solution. ::
 
-fig, axes = plot_snapshots(solutions, P, "u", "adjoint", levels=np.linspace(0, 0.8, 9))
+fig, axes = plot_snapshots(
+    solutions, time_partition, "u", "adjoint", levels=np.linspace(0, 0.8, 9)
+)
 fig.savefig("burgers2-end_time.jpg")
 
 # .. figure:: burgers2-end_time.jpg

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,3 +56,4 @@ earlier ones.
     Adjoint of Burgers equation <demos/burgers1.py>
     Adjoint of Burgers equation on two meshes <demos/burgers2.py>
     Adjoint of Burgers equation with a time-integrated QoI <demos/burgers-time_integrated.py>
+    Object-oriented approach to the adjoint of Burgers equation <demos/burgers-oo.py>

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -11,7 +11,7 @@ from functools import wraps
 import numpy as np
 
 
-__all__ = ["AdjointMeshSeq", "solve_adjoint"]
+__all__ = ["AdjointMeshSeq"]
 
 
 class AdjointMeshSeq(MeshSeq):
@@ -371,56 +371,3 @@ class AdjointMeshSeq(MeshSeq):
                 f" run do not match ({J_chk} vs. {self.J})"
             )
         return solutions
-
-
-def solve_adjoint(*args, **kwargs):
-    """
-    Solve an adjoint problem on a sequence of subintervals.
-
-    :arg time_partition: the :class:`TimePartition` which
-        partitions the temporal domain
-    :arg initial_meshes: list of meshes corresponding to
-        the subintervals of the :class:`TimePartition`,
-        or a single mesh to use for all subintervals
-    :arg get_function_spaces: a function, whose only
-        argument is a :class:`MeshSeq`, which constructs
-        prognostic :class:`FunctionSpace` s for each
-        subinterval
-    :arg get_initial_condition: a function, whose only
-        argument is a :class:`MeshSeq`, which specifies
-        initial conditions on the first mesh
-    :arg get_form: a function, whose only argument is a
-        :class:`MeshSeq`, which returns a function that
-        generates the PDE weak form
-    :arg get_solver: a function, whose only argument is
-        a :class:`MeshSeq`, which returns a function
-        that integrates initial data over a subinterval
-    :arg get_qoi: a function, with two arguments,
-        a :class:`AdjointMeshSeq`, which returns
-        a function of either one or two variables,
-        corresponding to either an end time or time
-        integrated quantity of interest, respectively,
-        as well as an index for the :class:`MeshSeq`
-    :kwarg get_bcs: a function, whose only argument is a
-        :class:`MeshSeq`, which returns a function that
-        determines any Dirichlet boundary conditions
-    :kwarg warnings: print warnings?
-    :kwarg solver_kwargs: a dictionary providing parameters
-        to the solver. Any keyword arguments for the QoI
-        should be included as a subdict with label 'qoi_kwargs'
-    :kwarg get_adj_values: additionally output adjoint
-        actions at exported timesteps
-    :kwarg test_checkpoint_qoi: solve over the final
-        subinterval when checkpointing so that the QoI
-        value can be checked across runs
-
-    :return solution: an :class:`AttrDict` containing
-        solution fields and their lagged versions.
-    """
-    assert len(args) == 7
-    solve_adjoint_kwargs = dict(
-        solver_kwargs=kwargs.pop("solver_kwargs", {}),
-        get_adj_values=kwargs.pop("get_adj_values", False),
-        test_checkpoint_qoi=kwargs.pop("test_checkpoint_qoi", False),
-    )
-    return AdjointMeshSeq(*args, **kwargs).solve_adjoint(**solve_adjoint_kwargs)

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -26,10 +26,10 @@ class MeshSeq(object):
         self,
         time_partition,
         initial_meshes,
-        get_function_spaces,
-        get_initial_condition,
-        get_form,
-        get_solver,
+        get_function_spaces=None,
+        get_initial_condition=None,
+        get_form=None,
+        get_solver=None,
         get_bcs=None,
         warnings=True,
         **kwargs,
@@ -40,17 +40,17 @@ class MeshSeq(object):
         :arg initial_meshes: list of meshes corresponding to
             the subintervals of the :class:`TimePartition`,
             or a single mesh to use for all subintervals
-        :arg get_function_spaces: a function, whose only
+        :kwarg get_function_spaces: a function, whose only
             argument is a :class:`MeshSeq`, which constructs
             prognostic :class:`FunctionSpace` s for each
             subinterval
-        :arg get_initial_condition: a function, whose only
+        :kwarg get_initial_condition: a function, whose only
             argument is a :class:`MeshSeq`, which specifies
             initial conditions on the first mesh
-        :arg get_form: a function, whose only argument is a
+        :kwarg get_form: a function, whose only argument is a
             :class:`MeshSeq`, which returns a function that
             generates the PDE weak form
-        :arg get_solver: a function, whose only argument is
+        :kwarg get_solver: a function, whose only argument is
             a :class:`MeshSeq`, which returns a function
             that integrates initial data over a subinterval
         :kwarg get_bcs: a function, whose only argument is a
@@ -66,14 +66,10 @@ class MeshSeq(object):
         if not isinstance(self.meshes, Iterable):
             self.meshes = [Mesh(initial_meshes) for subinterval in self.subintervals]
         self._fs = None
-        if get_function_spaces is not None:
-            self._get_function_spaces = get_function_spaces
-        if get_initial_condition is not None:
-            self._get_initial_condition = get_initial_condition
-        if get_form is not None:
-            self._get_form = get_form
-        if get_solver is not None:
-            self._get_solver = get_solver
+        self._get_function_spaces = get_function_spaces
+        self._get_initial_condition = get_initial_condition
+        self._get_form = get_form
+        self._get_solver = get_solver
         self._get_bcs = get_bcs
         self.warn = warnings
         self._lagged_dep_idx = {}
@@ -95,18 +91,28 @@ class MeshSeq(object):
         self.meshes[i] = mesh
 
     def get_function_spaces(self, mesh):
+        if self._get_function_spaces is None:
+            raise NotImplementedError("get_function_spaces needs implementing")
         return self._get_function_spaces(mesh)
 
     def get_initial_condition(self):
+        if self._get_initial_condition is None:
+            raise NotImplementedError("get_initial_condition needs implementing")
         return self._get_initial_condition(self)
 
     def get_form(self):
+        if self._get_form is None:
+            raise NotImplementedError("get_form needs implementing")
         return self._get_form(self)
 
     def get_solver(self):
+        if self._get_solver is None:
+            raise NotImplementedError("get_solver needs implementing")
         return self._get_solver(self)
 
     def get_bcs(self):
+        if self._get_bcs is None:
+            raise NotImplementedError("get_bcs needs implementing")
         return self._get_bcs(self)
 
     @property

--- a/pyroteus/thetis_compat.py
+++ b/pyroteus/thetis_compat.py
@@ -53,7 +53,7 @@ class FlowSolver2d(thetis.solver2d.FlowSolver2d):
         associated with its solvers.
         """
         self.update_tags()
-        super(FlowSolver2d, self).iterate(**kwargs)
+        super().iterate(**kwargs)
 
     def correct_counters(self, ts_data):
         """

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -184,7 +184,7 @@ class TimeInterval(TimePartition):
             end_time = args[0]
         timestep = args[1]
         fields = args[2]
-        super(TimeInterval, self).__init__(end_time, 1, timestep, fields, **kwargs)
+        super().__init__(end_time, 1, timestep, fields, **kwargs)
 
     def __repr__(self):
         return str(self[0])

--- a/pyroteus/utility.py
+++ b/pyroteus/utility.py
@@ -63,7 +63,7 @@ class File(firedrake.output.File):
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("adaptive", True)
-        super(File, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _write_vtu(self, *functions):
         """
@@ -79,7 +79,7 @@ class File(firedrake.output.File):
             for name, f in zip(self._fnames, functions):
                 if f.name() != name:
                     f.rename(name)
-        return super(File, self)._write_vtu(*functions)
+        return super()._write_vtu(*functions)
 
 
 @PETSc.Log.EventDecorator("pyroteus.assemble_mass_matrix")
@@ -267,7 +267,7 @@ class AttrDict(dict):
     """
 
     def __init__(self, *args, **kwargs):
-        super(AttrDict, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__dict__ = self
 
 

--- a/test/examples/point_discharge2d.py
+++ b/test/examples/point_discharge2d.py
@@ -54,6 +54,7 @@ def get_form(self):
     Advection-diffusion with SUPG
     stabilisation.
     """
+
     def form(i, sols):
         c, c_ = sols["tracer_2d"]
         fs = self.function_spaces["tracer_2d"][i]
@@ -76,6 +77,7 @@ def get_form(self):
             - inner(D * grad(c), grad(psi)) * dx
         )
         return F
+
     return form
 
 
@@ -84,9 +86,11 @@ def get_bcs(self):
     Zero Dirichlet condition on the
     left-hand (inlet) boundary.
     """
+
     def bcs(i):
         fs = self.function_spaces["tracer_2d"][i]
         return DirichletBC(fs, 0, 1)
+
     return bcs
 
 
@@ -130,14 +134,14 @@ def get_initial_condition(self):
     return {"tracer_2d": Function(self.function_spaces["tracer_2d"][0])}
 
 
-def get_qoi(self, i):
+def get_qoi(self, sol, i):
     """
     Quantity of interest which integrates
     the tracer concentration over an offset
     receiver region.
     """
 
-    def steady_qoi(sol):
+    def steady_qoi():
         c = sol["tracer_2d"]
         x, y = SpatialCoordinate(self[i])
         kernel = conditional((x - rec_x) ** 2 + (y - rec_y) ** 2 < rec_r**2, 1, 0)

--- a/test/examples/point_discharge3d.py
+++ b/test/examples/point_discharge3d.py
@@ -65,6 +65,7 @@ def get_form(self):
     Advection-diffusion with SUPG
     stabilisation.
     """
+
     def form(i, sols):
         c, c_ = sols["tracer_3d"]
         fs = self.function_spaces["tracer_3d"][i]
@@ -87,6 +88,7 @@ def get_form(self):
             - inner(D * grad(c), grad(psi)) * dx
         )
         return F
+
     return form
 
 
@@ -95,9 +97,11 @@ def get_bcs(self):
     Zero Dirichlet condition on the
     left-hand (inlet) boundary.
     """
+
     def bcs(i):
         fs = self.function_spaces["tracer_3d"][i]
         return DirichletBC(fs, 0, 1)
+
     return bcs
 
 
@@ -141,14 +145,14 @@ def get_initial_condition(self):
     return {"tracer_3d": Function(self.function_spaces["tracer_3d"][0])}
 
 
-def get_qoi(self, i):
+def get_qoi(self, sol, i):
     """
     Quantity of interest which integrates
     the tracer concentration over an offset
     receiver region.
     """
 
-    def steady_qoi(sol):
+    def steady_qoi():
         c = sol["tracer_3d"]
         x, y, z = SpatialCoordinate(self[i])
         kernel = conditional(

--- a/test/examples/solid_body_rotation_split.py
+++ b/test/examples/solid_body_rotation_split.py
@@ -67,10 +67,10 @@ def get_initial_condition(self, coordinates=None):
     }
 
 
-def get_qoi(self, i):
+def get_qoi(self, sol, i):
     """
     Unlike in the original version, the QoI
     is the squared L2 error for each shape,
     rather than just the slotted cylinder.
     """
-    return sbr.get_qoi(self, i, exact=get_initial_condition)
+    return sbr.get_qoi(self, sol, i, exact=get_initial_condition)

--- a/test/examples/steady_flow_past_cyl.py
+++ b/test/examples/steady_flow_past_cyl.py
@@ -48,6 +48,7 @@ def get_form(self):
             - inner(q, div(u)) * dx
         )
         return F
+
     return form
 
 
@@ -63,6 +64,7 @@ def get_bcs(self):
         noslip = DirichletBC(W.sub(0), (0, 0), (3, 5))
         inflow = DirichletBC(W.sub(0), interpolate(u_inflow, W.sub(0)), 1)
         return [inflow, noslip, DirichletBC(W.sub(0), 0, 4)]
+
     return bcs
 
 
@@ -118,13 +120,13 @@ def get_initial_condition(self):
     return {"up": up}
 
 
-def get_qoi(self, i):
+def get_qoi(self, sol, i):
     """
     Quantity of interest which integrates
     pressure over the boundary of the hole.
     """
 
-    def steady_qoi(sol):
+    def steady_qoi():
         u, p = sol["up"].split()
         return p * ds(4)
 

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -112,11 +112,11 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
     mesh_seq = AdjointMeshSeq(
         time_partition,
         test_case.mesh,
-        test_case.get_function_spaces,
-        test_case.get_initial_condition,
-        test_case.get_form,
-        test_case.get_solver,
-        test_case.get_qoi,
+        get_function_spaces=test_case.get_function_spaces,
+        get_initial_condition=test_case.get_initial_condition,
+        get_form=test_case.get_form,
+        get_solver=test_case.get_solver,
+        get_qoi=test_case.get_qoi,
         get_bcs=test_case.get_bcs,
         qoi_type=qoi_type,
         steady=steady,
@@ -127,8 +127,8 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
     ic = mesh_seq.initial_condition
     controls = [pyadjoint.Control(value) for key, value in ic.items()]
     sols = mesh_seq.solver(0, ic)
-    qoi = mesh_seq.get_qoi(0)
-    J = mesh_seq.J if qoi_type == "time_integrated" else qoi(sols)
+    qoi = mesh_seq.get_qoi(sols, 0)
+    J = mesh_seq.J if qoi_type == "time_integrated" else qoi()
     m = pyadjoint.enlisting.Enlist(controls)
     tape = pyadjoint.get_working_tape()
     with pyadjoint.stop_annotating():
@@ -165,11 +165,11 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
         mesh_seq = AdjointMeshSeq(
             time_partition,
             test_case.mesh,
-            test_case.get_function_spaces,
-            test_case.get_initial_condition,
-            test_case.get_form,
-            test_case.get_solver,
-            test_case.get_qoi,
+            get_function_spaces=test_case.get_function_spaces,
+            get_initial_condition=test_case.get_initial_condition,
+            get_form=test_case.get_form,
+            get_solver=test_case.get_solver,
+            get_qoi=test_case.get_qoi,
             get_bcs=test_case.get_bcs,
             qoi_type=qoi_type,
         )
@@ -239,11 +239,11 @@ def plot_solutions(problem, qoi_type, debug=True):
     solutions = AdjointMeshSeq(
         time_partition,
         test_case.mesh,
-        test_case.get_function_spaces,
-        test_case.get_initial_condition,
-        test_case.get_form,
-        test_case.get_solver,
-        test_case.get_qoi,
+        get_function_spaces=test_case.get_function_spaces,
+        get_initial_condition=test_case.get_initial_condition,
+        get_form=test_case.get_form,
+        get_solver=test_case.get_solver,
+        get_qoi=test_case.get_qoi,
         get_bcs=test_case.get_bcs,
         qoi_type=qoi_type,
         steady=steady,

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -54,7 +54,6 @@ all_problems = [
     "solid_body_rotation",
     "solid_body_rotation_split",
     "rossby_wave",
-    "migrating_trench",
 ]
 
 


### PR DESCRIPTION
In this PR, the `get_form`, `get_solver`, `get_qoi`, ... functions become kwargs of `MeshSeq`, rather than arguments. They still need to be set, but this makes it easier to take a subclass approach and it means that the order they are passed in no longer matters. However, previous code that passes them in order should still work.