### PR TITLE
Provide default initial conditions

### DIFF
--- a/demos/point_discharge.py
+++ b/demos/point_discharge.py
@@ -135,18 +135,13 @@ def get_solver(mesh_seq):
 # programatic dependence on the initial condition so that it is possible to
 # automatically differentiate the QoI with respect to this as an input.
 #
-# In the same way, :func:`get_initial_condition` is required, but fairly artificial.
-# ::
-
-def get_initial_condition(mesh_seq):
-    return {"c": Function(mesh_seq.function_spaces["c"][0])}
-
-
-# As in the motivation for the manual, we consider a quantity of interest that
-# integrates the tracer concentration over a circular "receiver" region.
+# For steady-state problems, we do not need to specify :func:`get_initial_condition`
+# if the equation is linear. If the equation is nonlinear then this would provide
+# an initial guess. By default, all components are initialised to zero.
 #
-# Since there is no time dependence, the QoI looks just like an ``"end_time"``
-# type QoI. ::
+# As in the motivation for the manual, we consider a quantity of interest that
+# integrates the tracer concentration over a circular "receiver" region. Since
+# there is no time dependence, the QoI looks just like an ``"end_time"`` type QoI. ::
 
 def get_qoi(mesh_seq, sol, index):
     def qoi():
@@ -172,7 +167,6 @@ mesh_seq = GoalOrientedMeshSeq(
     time_partition,
     mesh,
     get_function_spaces=get_function_spaces,
-    get_initial_condition=get_initial_condition,
     get_form=get_form,
     get_bcs=get_bcs,
     get_solver=get_solver,

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -145,9 +145,12 @@ class MeshSeq(object):
         return self._get_function_spaces(mesh)
 
     def get_initial_condition(self):
-        if self._get_initial_condition is None:
-            raise NotImplementedError("get_initial_condition needs implementing")
-        return self._get_initial_condition(self)
+        if self._get_initial_condition is not None:
+            return self._get_initial_condition(self)
+        return {
+            field: firedrake.Function(fs[0])
+            for field, fs in self.function_spaces.items()
+        }
 
     def get_form(self):
         if self._get_form is None:
@@ -160,9 +163,8 @@ class MeshSeq(object):
         return self._get_solver(self)
 
     def get_bcs(self):
-        if self._get_bcs is None:
-            raise NotImplementedError("get_bcs needs implementing")
-        return self._get_bcs(self)
+        if self._get_bcs is not None:
+            return self._get_bcs(self)
 
     @property
     def _function_spaces_consistent(self):

--- a/test/examples/point_discharge2d.py
+++ b/test/examples/point_discharge2d.py
@@ -30,6 +30,7 @@ dt_per_export = 1
 src_x, src_y, src_r = 2.0, 5.0, 0.05606388
 rec_x, rec_y, rec_r = 20.0, 7.5, 0.5
 steady = True
+get_initial_condition = None
 
 
 def get_function_spaces(mesh):
@@ -123,15 +124,6 @@ def get_solver(self):
         return {"tracer_2d": c}
 
     return solver
-
-
-def get_initial_condition(self):
-    """
-    Dummy initial condition function which
-    acts merely to pass over the
-    :class:`FunctionSpace`.
-    """
-    return {"tracer_2d": Function(self.function_spaces["tracer_2d"][0])}
 
 
 def get_qoi(self, sol, i):

--- a/test/examples/point_discharge3d.py
+++ b/test/examples/point_discharge3d.py
@@ -39,6 +39,7 @@ dt_per_export = 1
 src_x, src_y, src_z, src_r = 2.0, 5.0, 5.0, 6.51537538e-02
 rec_x, rec_y, rec_z, rec_r = 20.0, 7.5, 7.5, 0.5
 steady = True
+get_initial_condition = None
 
 
 def get_function_spaces(mesh):
@@ -134,15 +135,6 @@ def get_solver(self):
         return {"tracer_3d": c}
 
     return solver
-
-
-def get_initial_condition(self):
-    """
-    Dummy initial condition function which
-    acts merely to pass over the
-    :class:`FunctionSpace`.
-    """
-    return {"tracer_3d": Function(self.function_spaces["tracer_3d"][0])}
 
 
 def get_qoi(self, sol, i):


### PR DESCRIPTION
For linear steady-state problems it feels artificial to have to provide initial conditions. This PR means that we just use zero "initial conditions" under the hood, unless told otherwise.