### PR TITLE
Move `AdaptParameters` and co to a separate file

### DIFF
--- a/pyroteus/__init__.py
+++ b/pyroteus/__init__.py
@@ -2,10 +2,11 @@ from pyroteus.utility import *  # noqa
 from pyroteus.time_partition import *  # noqa
 from pyroteus.recovery import *  # noqa
 from pyroteus.plot import *  # noqa
+from pyroteus.log import *  # noqa
 from pyroteus.math import *  # noqa
 from pyroteus.metric import *  # noqa
 from pyroteus.mesh_seq import *  # noqa
-from pyroteus.log import *  # noqa
+from pyroteus.options import *  # noqa
 from pyroteus.interpolation import *  # noqa
 from pyroteus.error_estimation import *  # noqa
 from pyroteus.form import *  # noqa

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -4,45 +4,13 @@ Drivers for goal-oriented error estimation on sequences of meshes.
 from .adjoint import AdjointMeshSeq
 from .error_estimation import get_dwr_indicator, indicators2estimator
 from .log import pyrint
-from .mesh_seq import AdaptParameters
-from .metric import MetricParameters
 from firedrake import Function, FunctionSpace, MeshHierarchy, TransferManager, project
 from firedrake.petsc import PETSc
 from collections.abc import Callable
 from typing import Tuple
 
 
-__all__ = [
-    "GoalOrientedParameters",
-    "GoalOrientedMetricParameters",
-    "GoalOrientedMeshSeq",
-]
-
-
-class GoalOrientedParameters(AdaptParameters):
-    """
-    A class for holding parameters associated with
-    goal-oriented adaptive mesh fixed point iteration
-    loops.
-    """
-
-    def __init__(self, parameters: dict = {}):
-        self["qoi_rtol"] = 0.001  # Relative tolerance for QoI
-        self["estimator_rtol"] = 0.001  # Relative tolerance for estimator
-
-        super().__init__(parameters=parameters)
-
-
-class GoalOrientedMetricParameters(GoalOrientedParameters):
-    """
-    A class for holding parameters associated with
-    metric-based, goal-oriented adaptive mesh fixed
-    point iteration loops.
-    """
-
-    def __init__(self, parameters: dict = {}):
-        MetricParameters.__init__(self)
-        super().__init__(parameters=parameters)
+__all__ = ["GoalOrientedMeshSeq"]
 
 
 class GoalOrientedMeshSeq(AdjointMeshSeq):

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -5,6 +5,7 @@ import firedrake
 from firedrake.petsc import PETSc
 from .interpolation import project
 from .log import pyrint, debug, warning, logger, DEBUG
+from .options import AdaptParameters
 from .quality import QualityMeasure
 from .time_partition import TimePartition
 from .utility import AttrDict, Function, Mesh, MeshGeometry
@@ -16,34 +17,7 @@ import numpy as np
 from typing import Tuple
 
 
-__all__ = ["AdaptParameters", "MeshSeq"]
-
-
-class AdaptParameters(AttrDict):
-    """
-    A class for holding parameters associated with
-    adaptive mesh fixed point iteration loops.
-    """
-
-    def __init__(self, parameters: dict = {}):
-        """
-        :arg parameters: dictionary of parameters to set
-        """
-        self["miniter"] = 3  # Minimum iteration count
-        self["maxiter"] = 35  # Maximum iteration count
-        self["element_rtol"] = 0.001  # Relative tolerance for element count
-
-        for key, value in parameters.items():
-            if key not in self:
-                raise AttributeError(f"{self} does not have {key} attribute")
-            self[key] = value
-
-    def __str__(self) -> str:
-        return str({key: value for key, value in self.items()})
-
-    def __repr__(self) -> str:
-        d = ", ".join([f"{key}={value}" for key, value in self.items()])
-        return f"{self.__class__.__name__}({d})"
+__all__ = ["MeshSeq"]
 
 
 class MeshSeq:

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -3,13 +3,11 @@ Driver functions for metric-based mesh adaptation.
 """
 from .utility import *
 from .interpolation import clement_interpolant
-from .mesh_seq import AdaptParameters
 from collections.abc import Iterable
 from typing import List, Optional, Tuple, Union
 
 
 __all__ = [
-    "MetricParameters",
     "compute_eigendecomposition",
     "assemble_eigendecomposition",
     "metric_complexity",
@@ -30,27 +28,6 @@ __all__ = [
     "metric_logarithm",
     "ramp_complexity",
 ]
-
-
-class MetricParameters(AdaptParameters):
-    """
-    A class for holding parameters associated with
-    metric-based adaptive mesh fixed point iteration loops.
-    """
-
-    def __init__(self, parameters: dict = {}):
-        """
-        :arg parameters: dictionary of parameters to set
-        """
-        self["h_min"] = 1.0e-30  # Minimum metric magnitude
-        self["h_max"] = 1.0e30  # Maximum metric magnitude
-        self["a_max"] = 1.0e30  # Maximum anisotropy
-        self["p"] = 1.0  # Metric normalisation order
-        self["base_complexity"] = 200.0  # Base metric complexity
-        self["target_complexity"] = 4000.0  # Target metric complexity
-        self["num_ramp_iterations"] = 3  # Number of iterations to ramp over
-
-        super().__init__(parameters=parameters)
 
 
 def get_metric_kernel(func: str, dim: int) -> op2.Kernel:

--- a/pyroteus/options.py
+++ b/pyroteus/options.py
@@ -1,0 +1,111 @@
+from .utility import AttrDict
+
+
+__all__ = [
+    "AdaptParameters",
+    "MetricParameters",
+    "GoalOrientedParameters",
+    "GoalOrientedMetricParameters",
+]
+
+
+class AdaptParameters(AttrDict):
+    """
+    A class for holding parameters associated with adaptive mesh fixed point iteration
+    loops.
+    """
+
+    def __init__(self, parameters: dict = {}):
+        """
+        :arg parameters: dictionary of parameters to set
+        """
+        self["miniter"] = 3  # Minimum iteration count
+        self["maxiter"] = 35  # Maximum iteration count
+        self["element_rtol"] = 0.001  # Relative tolerance for element count
+
+        if not isinstance(parameters, dict):
+            raise TypeError(
+                "Expected 'parameters' keyword argument to be a dictionary, not of"
+                f" type '{parameters.__class__.__name__}'."
+            )
+        for key, value in parameters.items():
+            if key not in self:
+                raise AttributeError(
+                    f"{self.__class__.__name__} does not have '{key}' attribute."
+                )
+        super().__init__(parameters)
+        self._check_type("miniter", int)
+        self._check_type("maxiter", int)
+        self._check_type("element_rtol", (float, int))
+
+    def _check_type(self, key, expected):
+        if not isinstance(self[key], expected):
+            if isinstance(expected, tuple):
+                name = "' or '".join([e.__name__ for e in expected])
+            else:
+                name = expected.__name__
+            raise TypeError(
+                f"Expected attribute '{key}' to be of type '{name}', not"
+                f" '{type(self[key]).__name__}'."
+            )
+
+    def __str__(self) -> str:
+        return str({key: value for key, value in self.items()})
+
+    def __repr__(self) -> str:
+        d = ", ".join([f"{key}={value}" for key, value in self.items()])
+        return f"{self.__class__.__name__}({d})"
+
+
+class MetricParameters(AdaptParameters):
+    """
+    A class for holding parameters associated with
+    metric-based adaptive mesh fixed point iteration loops.
+    """
+
+    def __init__(self, parameters: dict = {}):
+        """
+        :arg parameters: dictionary of parameters to set
+        """
+        self["h_min"] = 1.0e-30  # Minimum metric magnitude
+        self["h_max"] = 1.0e30  # Maximum metric magnitude
+        self["a_max"] = 1.0e30  # Maximum anisotropy
+        self["p"] = 1.0  # Metric normalisation order
+        self["base_complexity"] = 200.0  # Base metric complexity
+        self["target_complexity"] = 4000.0  # Target metric complexity
+        self["num_ramp_iterations"] = 3  # Number of iterations to ramp over
+
+        super().__init__(parameters=parameters)
+
+        self._check_type("h_min", (float, int))
+        self._check_type("h_max", (float, int))
+        self._check_type("a_max", (float, int))
+        self._check_type("p", (float, int))
+        self._check_type("base_complexity", (float, int))
+        self._check_type("target_complexity", (float, int))
+        self._check_type("num_ramp_iterations", int)
+
+
+class GoalOrientedParameters(AdaptParameters):
+    """
+    A class for holding parameters associated with
+    goal-oriented adaptive mesh fixed point iteration
+    loops.
+    """
+
+    def __init__(self, parameters: dict = {}):
+        self["qoi_rtol"] = 0.001  # Relative tolerance for QoI
+        self["estimator_rtol"] = 0.001  # Relative tolerance for estimator
+
+        super().__init__(parameters=parameters)
+
+        self._check_type("qoi_rtol", (float, int))
+        self._check_type("estimator_rtol", (float, int))
+
+
+class GoalOrientedMetricParameters(GoalOrientedParameters, MetricParameters):
+    """
+    A class for holding parameters associated with
+    metric-based, goal-oriented adaptive mesh fixed
+    point iteration loops.
+    """

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -194,5 +194,46 @@ class TestGoalOrientedParameters(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg)
 
 
+class TestGoalOrientedMetricParameters(unittest.TestCase):
+    """
+    Unit tests for the :class:`GoalOrientedMetricParameters` class.
+    """
+
+    def setUp(self):
+        self.defaults = {
+            "qoi_rtol": 0.001,
+            "estimator_rtol": 0.001,
+            "h_min": 1.0e-30,
+            "h_max": 1.0e30,
+            "a_max": 1.0e30,
+            "p": 1.0,
+            "base_complexity": 200.0,
+            "target_complexity": 4000.0,
+            "num_ramp_iterations": 3,
+            "miniter": 3,
+            "maxiter": 35,
+            "element_rtol": 0.001,
+        }
+
+    def test_defaults(self):
+        ap = GoalOrientedMetricParameters()
+        for key, value in self.defaults.items():
+            self.assertEqual(ap[key], value)
+
+    def test_str(self):
+        ap = GoalOrientedMetricParameters()
+        self.assertEqual(str(ap), str(self.defaults))
+
+    def test_repr(self):
+        ap = GoalOrientedMetricParameters()
+        expected = (
+            "GoalOrientedMetricParameters(qoi_rtol=0.001, estimator_rtol=0.001,"
+            " h_min=1e-30, h_max=1e+30, a_max=1e+30, p=1.0, base_complexity=200.0,"
+            " target_complexity=4000.0, num_ramp_iterations=3, miniter=3, maxiter=35,"
+            " element_rtol=0.001)"
+        )
+        self.assertEqual(repr(ap), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -147,5 +147,52 @@ class TestMetricParameters(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg)
 
 
+class TestGoalOrientedParameters(unittest.TestCase):
+    """
+    Unit tests for the :class:`GoalOrientedParameters` class.
+    """
+
+    def setUp(self):
+        self.defaults = {
+            "qoi_rtol": 0.001,
+            "estimator_rtol": 0.001,
+            "miniter": 3,
+            "maxiter": 35,
+            "element_rtol": 0.001,
+        }
+
+    def test_defaults(self):
+        ap = GoalOrientedParameters()
+        for key, value in self.defaults.items():
+            self.assertEqual(ap[key], value)
+
+    def test_str(self):
+        ap = GoalOrientedParameters()
+        self.assertEqual(str(ap), str(self.defaults))
+
+    def test_repr(self):
+        ap = GoalOrientedParameters()
+        expected = (
+            "GoalOrientedParameters(qoi_rtol=0.001, estimator_rtol=0.001, miniter=3,"
+            " maxiter=35, element_rtol=0.001)"
+        )
+        self.assertEqual(repr(ap), expected)
+
+    def test_qoi_rtol_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            GoalOrientedParameters({"qoi_rtol": "0.001"})
+        msg = "Expected attribute 'qoi_rtol' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_estimator_rtol_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            GoalOrientedParameters({"estimator_rtol": "0.001"})
+        msg = (
+            "Expected attribute 'estimator_rtol' to be of type 'float' or 'int', not"
+            " 'str'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -62,3 +62,90 @@ class TestAdaptParameters(unittest.TestCase):
             AdaptParameters({"element_rtol": "0.001"})
         msg = "Expected attribute 'element_rtol' to be of type 'float' or 'int', not 'str'."
         self.assertEqual(str(cm.exception), msg)
+
+
+class TestMetricParameters(unittest.TestCase):
+    """
+    Unit tests for the :class:`MetricParameters` class.
+    """
+
+    def setUp(self):
+        self.defaults = {
+            "h_min": 1.0e-30,
+            "h_max": 1.0e30,
+            "a_max": 1.0e30,
+            "p": 1.0,
+            "base_complexity": 200.0,
+            "target_complexity": 4000.0,
+            "num_ramp_iterations": 3,
+            "miniter": 3,
+            "maxiter": 35,
+            "element_rtol": 0.001,
+        }
+
+    def test_defaults(self):
+        ap = MetricParameters()
+        for key, value in self.defaults.items():
+            self.assertEqual(ap[key], value)
+
+    def test_str(self):
+        ap = MetricParameters()
+        self.assertEqual(str(ap), str(self.defaults))
+
+    def test_repr(self):
+        ap = MetricParameters()
+        expected = (
+            "MetricParameters(h_min=1e-30, h_max=1e+30, a_max=1e+30, p=1.0,"
+            " base_complexity=200.0, target_complexity=4000.0, num_ramp_iterations=3,"
+            " miniter=3, maxiter=35, element_rtol=0.001)"
+        )
+        self.assertEqual(repr(ap), expected)
+
+    def test_hmin_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            MetricParameters({"h_min": "1.0e-30"})
+        msg = "Expected attribute 'h_min' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_hmax_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            MetricParameters({"h_max": "1.0e30"})
+        msg = "Expected attribute 'h_max' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_amax_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            MetricParameters({"a_max": "1.0e30"})
+        msg = "Expected attribute 'a_max' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_p_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            MetricParameters({"p": "1.0"})
+        msg = "Expected attribute 'p' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_base_complexity_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            MetricParameters({"base_complexity": "200.0"})
+        msg = "Expected attribute 'base_complexity' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_target_complexity_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            MetricParameters({"target_complexity": "4000.0"})
+        msg = "Expected attribute 'target_complexity' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_ramp_iter_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            MetricParameters({"num_ramp_iterations": 3.0})
+        msg = (
+            "Expected attribute 'num_ramp_iterations' to be of type 'int', not"
+            " 'float'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -1,0 +1,64 @@
+from pyroteus.options import *
+import unittest
+
+
+class TestAdaptParameters(unittest.TestCase):
+    """
+    Unit tests for the base :class:`AdaptParameters` class.
+    """
+
+    def setUp(self):
+        self.defaults = {"miniter": 3, "maxiter": 35, "element_rtol": 0.001}
+
+    def test_input(self):
+        with self.assertRaises(TypeError) as cm:
+            AdaptParameters(1)
+        msg = (
+            "Expected 'parameters' keyword argument to be a dictionary, not of type"
+            " 'int'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_attribute_error(self):
+        with self.assertRaises(AttributeError) as cm:
+            AdaptParameters({"key": "value"})
+        msg = "AdaptParameters does not have 'key' attribute."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_defaults(self):
+        ap = AdaptParameters()
+        for key, value in self.defaults.items():
+            self.assertEqual(ap[key], value)
+
+    def test_access(self):
+        ap = AdaptParameters()
+        self.assertEqual(ap.miniter, ap["miniter"])
+        self.assertEqual(ap.maxiter, ap["maxiter"])
+        self.assertEqual(ap.element_rtol, ap["element_rtol"])
+
+    def test_str(self):
+        ap = AdaptParameters()
+        self.assertEqual(str(ap), str(self.defaults))
+
+    def test_repr(self):
+        ap = AdaptParameters()
+        expected = "AdaptParameters(miniter=3, maxiter=35, element_rtol=0.001)"
+        self.assertEqual(repr(ap), expected)
+
+    def test_miniter_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            AdaptParameters({"miniter": 3.0})
+        msg = "Expected attribute 'miniter' to be of type 'int', not 'float'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_maxiter_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            AdaptParameters({"maxiter": 35.0})
+        msg = "Expected attribute 'maxiter' to be of type 'int', not 'float'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_element_rtol_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            AdaptParameters({"element_rtol": "0.001"})
+        msg = "Expected attribute 'element_rtol' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)


### PR DESCRIPTION
Closes #95 and #97.

This PR moves `AdaptParameters` and its subclasses to a common file, `options.py`. It also implements some basic type checking and fixes a bug in the initialisation. Unit tests are added to avoid hitting bugs in the future.