### PR TITLE
Add unit tests for adjoint utils

### DIFF
--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -414,7 +414,6 @@ class AdjointMeshSeq(MeshSeq):
         self.converged = False
         if len(self.qoi_values) < max(2, P.miniter):
             return
-        self.converged = True
         qoi_ = self.qoi_values[-2]
         qoi = self.qoi_values[-1]
         if abs(qoi - qoi_) < P.qoi_rtol * abs(qoi_):

--- a/pyroteus/interpolation.py
+++ b/pyroteus/interpolation.py
@@ -201,7 +201,7 @@ def mesh2mesh_project(
     elif hasattr(target_space, "num_sub_spaces"):
         assert hasattr(source_space, "num_sub_spaces")
         assert target_space.num_sub_spaces() == source_space.num_sub_spaces()
-        for s, t in zip(source.split(), target.split()):
+        for s, t in zip(source.subfunctions, target.subfunctions):
             t.project(s, **kwargs)
     else:
         target.project(source, **kwargs)
@@ -245,8 +245,8 @@ def mesh2mesh_project_adjoint(
             raise ValueError(f"Incompatible spaces {source_space} and {target_space}")
         if not target_space.num_sub_spaces() == source_space.num_sub_spaces():
             raise ValueError(f"Incompatible spaces {source_space} and {target_space}")
-        target_b_split = target_b.split()
-        source_b_split = source_b.split()
+        target_b_split = target_b.subfunctions
+        source_b_split = source_b.subfunctions
     elif hasattr(target_space, "num_sub_spaces"):
         raise ValueError(f"Incompatible spaces {source_space} and {target_space}")
     else:

--- a/pyroteus/interpolation.py
+++ b/pyroteus/interpolation.py
@@ -158,7 +158,9 @@ def project(
         target_space = target.function_space()
     else:
         target = Function(target_space)
-    if source_space.ufl_domain() == target_space.ufl_domain():
+    if ufl.domain.extract_unique_domain(source) == ufl.domain.extract_unique_domain(
+        target
+    ):
         if source_space == target_space:
             target.assign(source)
         else:

--- a/pyroteus/math.py
+++ b/pyroteus/math.py
@@ -118,7 +118,7 @@ def construct_orthonormal_basis(v, dim=None, seed=0):
     :kwarg seed: seed for random number generator
     """
     np.random.seed(seed)
-    dim = dim or v.ufl_domain().topological_dimension()
+    dim = dim or ufl.domain.extract_unique_domain(v).topological_dimension()
     if dim == 2:
         return [ufl.perp(v)]
     elif dim > 2:

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -323,6 +323,7 @@ class MeshSeq:
         )
 
         # Default adjoint solution to zero, rather than None
+        # TODO: This should be in adjoint subclass
         if has_adj_sol:
             if all(block.adj_sol is None for block in solve_blocks):
                 self.warning(

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -7,6 +7,7 @@ from firedrake.meshadapt import RiemannianMetric
 from .interpolation import clement_interpolant
 from collections.abc import Iterable
 from typing import List, Optional, Tuple, Union
+import ufl
 
 
 __all__ = [
@@ -154,7 +155,7 @@ def isotropic_metric(
         :class:`firedrake.meshadapt.RiemannianMetric`
     """
     target_space = kwargs.get("target_space")
-    mesh = error_indicator.ufl_domain()
+    mesh = ufl.domain.extract_unique_domain(error_indicator)
     dim = mesh.topological_dimension()
     assert dim in (2, 3), f"Spatial dimension {dim:d} not supported."
     target_space = target_space or firedrake.TensorFunctionSpace(mesh, "CG", 1)
@@ -266,7 +267,7 @@ def anisotropic_dwr_metric(
         raise ValueError(
             f"Target complexity must be positive, not {target_complexity}."
         )
-    mesh = error_indicator.ufl_domain()
+    mesh = ufl.domain.extract_unique_domain(error_indicator)
     dim = mesh.topological_dimension()
     if dim not in (2, 3):
         raise ValueError(f"Spatial dimension {dim} not supported. Must be 2 or 3.")
@@ -357,7 +358,7 @@ def weighted_hessian_metric(
         error_indicators = [error_indicators]
     if not isinstance(hessians, Iterable):
         hessians = [hessians]
-    mesh = hessians[0].ufl_domain()
+    mesh = ufl.domain.extract_unique_domain(hessians[0])
     dim = mesh.topological_dimension()
     if dim not in (2, 3):
         raise ValueError(f"Spatial dimension {dim:d} not supported. Must be 2 or 3.")

--- a/pyroteus/recovery.py
+++ b/pyroteus/recovery.py
@@ -137,7 +137,7 @@ def double_l2_projection(
         )
         sp = {"pc_mat_factor_solver_type": "mumps"}
         firedrake.solve(a == L, l2_projection, solver_parameters=sp)
-    return l2_projection.split()
+    return l2_projection.subfunctions
 
 
 @PETSc.Log.EventDecorator("pyroteus.recovery_boundary_hessian")

--- a/pyroteus/utility.py
+++ b/pyroteus/utility.py
@@ -207,7 +207,7 @@ def errornorm(u, uh: Function, norm_type: str = "L2", **kwargs) -> float:
     # Case 2: UFL norms for mixed function spaces
     elif hasattr(uh.function_space(), "num_sub_spaces"):
         if norm_type == "L2":
-            vv = [uu - uuh for uu, uuh in zip(u.split(), uh.split())]
+            vv = [uu - uuh for uu, uuh in zip(u.subfunctions, uh.subfunctions)]
             dX = ufl.ds if kwargs.get("boundary", False) else ufl.dx
             return ufl.sqrt(firedrake.assemble(sum([ufl.inner(v, v) for v in vv]) * dX))
         else:

--- a/test_adjoint/examples/steady_flow_past_cyl.py
+++ b/test_adjoint/examples/steady_flow_past_cyl.py
@@ -115,7 +115,7 @@ def get_initial_condition(self):
     x, y = SpatialCoordinate(self[0])
     u_inflow = as_vector([y * (10 - y) / 25.0, 0])
     up = Function(self.function_spaces["up"][0])
-    u, p = up.split()
+    u, p = up.subfunctions
     u.interpolate(u_inflow)
     return {"up": up}
 
@@ -127,7 +127,7 @@ def get_qoi(self, sol, i):
     """
 
     def steady_qoi():
-        u, p = sol["up"].split()
+        u, p = split(sol["up"])
         return p * ds(4)
 
     return steady_qoi

--- a/test_adjoint/test_adjoint.py
+++ b/test_adjoint/test_adjoint.py
@@ -254,7 +254,9 @@ def plot_solutions(problem, qoi_type, debug=True):
             to_plot = []
             for field in time_partition.fields:
                 sol = solutions[field][label][0][k]
-                to_plot += [sol] if not hasattr(sol, "split") else list(sol.split())
+                to_plot += (
+                    [sol] if not hasattr(sol, "split") else list(sol.subfunctions)
+                )
             outfiles[label].write(*to_plot)
 
 

--- a/test_adjoint/test_adjoint.py
+++ b/test_adjoint/test_adjoint.py
@@ -181,8 +181,11 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
         # Check adjoint solutions at initial time match
         for field in time_partition.fields:
             adj_sol_expected = adj_sols_expected[field]
+            expected_norm = norm(adj_sol_expected)
+            if np.isclose(expected_norm, 0.0):
+                raise ValueError("'Expected' norm at t=0 is unexpectedly zero.")
             adj_sol_computed = solutions[field].adjoint[0][0]
-            err = errornorm(adj_sol_expected, adj_sol_computed) / norm(adj_sol_expected)
+            err = errornorm(adj_sol_expected, adj_sol_computed) / expected_norm
             if not np.isclose(err, 0.0):
                 raise ValueError(
                     f"Adjoint solutions do not match at t=0 (error {err:.4e}.)"
@@ -255,7 +258,7 @@ def plot_solutions(problem, qoi_type, debug=True):
             for field in time_partition.fields:
                 sol = solutions[field][label][0][k]
                 to_plot += (
-                    [sol] if not hasattr(sol, "split") else list(sol.subfunctions)
+                    [sol] if not hasattr(sol, "subfunctions") else list(sol.subfunctions)
                 )
             outfiles[label].write(*to_plot)
 
@@ -263,15 +266,17 @@ def plot_solutions(problem, qoi_type, debug=True):
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(prog="test/test_adjoint.py")
-    parser.add_argument("problem")
-    parser.add_argument("qoi_type")
-    parser.add_argument("-plot")
+    parser = argparse.ArgumentParser(
+        prog="test/test_adjoint.py",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("problem", type=str)
+    parser.add_argument("qoi_type", type=str)
+    parser.add_argument("--plot", action="store_true")
     args = parser.parse_args()
     assert args.qoi_type in ("end_time", "time_integrated", "steady")
     assert args.problem in all_problems
-    plot = bool(args.plot or False)
-    if plot:
+    if args.plot:
         plot_solutions(args.problem, args.qoi_type, debug=True)
     else:
         test_adjoint_same_mesh(args.problem, args.qoi_type, debug=True)

--- a/test_adjoint/test_utils.py
+++ b/test_adjoint/test_utils.py
@@ -1,0 +1,115 @@
+from firedrake import *
+from pyroteus_adjoint import *
+from pyroteus.adjoint import annotate_qoi
+import numpy as np
+import unittest
+
+
+class TestAdjointUtils(unittest.TestCase):
+    """
+    Unit tests for adjoint utils.
+    """
+
+    def setUp(self):
+        self.time_interval = TimeInterval(1.0, [0.5], ["field"])
+        self.mesh = UnitSquareMesh(1, 1)
+
+    def mesh_seq(self, qoi_type="end_time"):
+        return AdjointMeshSeq(self.time_interval, [self.mesh], qoi_type=qoi_type)
+
+    def test_annotate_qoi_0args(self):
+        @annotate_qoi
+        def get_qoi(mesh_seq, solution_map, i):
+            def qoi():
+                return Constant(1.0, domain=mesh_seq[i]) * dx
+
+            return qoi
+
+        get_qoi(self.mesh_seq("steady"), {}, 0)
+
+    def test_annotate_qoi_1arg(self):
+        @annotate_qoi
+        def get_qoi(mesh_seq, solution_map, i):
+            def qoi(t):
+                return Constant(1.0, domain=mesh_seq[i]) * dx
+
+            return qoi
+
+        get_qoi(self.mesh_seq("time_integrated"), {}, 0)
+
+    def test_annotate_qoi_0args_error(self):
+        @annotate_qoi
+        def get_qoi(mesh_seq, solution_map, i):
+            def qoi():
+                return Constant(1.0, domain=mesh_seq[i]) * dx
+
+            return qoi
+
+        with self.assertRaises(ValueError) as cm:
+            get_qoi(self.mesh_seq("time_integrated"), {}, 0)
+        msg = "Expected qoi_type to be 'end_time' or 'steady', not 'time_integrated'."
+        assert str(cm.exception) == msg
+
+    def test_annotate_qoi_1arg_error(self):
+        @annotate_qoi
+        def get_qoi(mesh_seq, solution_map, i):
+            def qoi(t):
+                return Constant(1.0, domain=mesh_seq[i]) * dx
+
+            return qoi
+
+        with self.assertRaises(ValueError) as cm:
+            get_qoi(self.mesh_seq("steady"), {}, 0)
+        msg = "Expected qoi_type to be 'time_integrated', not 'steady'."
+        assert str(cm.exception) == msg
+
+    def test_annotate_qoi_2args_error(self):
+        @annotate_qoi
+        def get_qoi(mesh_seq, solution_map, i):
+            def qoi(t, r):
+                return Constant(1.0, domain=mesh_seq[i]) * dx
+
+            return qoi
+
+        with self.assertRaises(ValueError) as cm:
+            get_qoi(self.mesh_seq("time_integrated"), {}, 0)
+        assert str(cm.exception) == "QoI should have 0 or 1 args, not 2."
+
+    def test_qoi_type_error(self):
+        with self.assertRaises(ValueError) as cm:
+            self.mesh_seq("qoi_type")
+        msg = (
+            "QoI type 'qoi_type' not recognised."
+            " Choose from 'end_time', 'time_integrated', or 'steady'."
+        )
+        assert str(cm.exception) == msg
+
+    def test_qoi_notimplemented(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            self.mesh_seq("end_time").get_qoi({}, 0)
+        assert str(cm.exception) == "'get_qoi' is not implemented."
+
+    def test_qoi_convergence_values_lt_2(self):
+        mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.qoi_values = [1.0]
+        mesh_seq.check_qoi_convergence()
+        self.assertFalse(mesh_seq.converged)
+
+    def test_qoi_convergence_values_lt_miniter(self):
+        mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter - 1)
+        mesh_seq.check_qoi_convergence()
+        self.assertFalse(mesh_seq.converged)
+
+    def test_qoi_convergence_values_constant(self):
+        mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter)
+        mesh_seq.check_qoi_convergence()
+        self.assertTrue(mesh_seq.converged)
+
+    def test_qoi_convergence_values_not_converged(self):
+        mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter)
+        mesh_seq.qoi_values[-1] = 100.0
+        mesh_seq.check_qoi_convergence()
+        self.assertFalse(mesh_seq.converged)


### PR DESCRIPTION
This PR adds unit tests for the utility functions associated with `pyroteus/adjoint.py`. It also helps to avoid many of the deprecation warnings that arise when accessing the `ufl_domain` method of UFL objects.

Partially addresses #77.