### PR TITLE
Add unit tests for error estimation

### DIFF
--- a/pyroteus/error_estimation.py
+++ b/pyroteus/error_estimation.py
@@ -15,11 +15,17 @@ __all__ = ["get_dwr_indicator"]
 
 
 @PETSc.Log.EventDecorator()
-def form2indicator(F) -> Function:
-    """
-    Multiply throughout in a form and assemble as a cellwise error indicator.
+def form2indicator(F: ufl.form.Form) -> Function:
+    r"""
+    Given a 0-form, multiply the integrand of each of its integrals by a
+    :math:`\mathbb P0` test function and reassemble to give an element-wise error
+    indicator.
 
-    :arg F: the form
+    Note that a 0-form does not contain any :class:`firedrake.ufl_expr.TestFunction`\s
+    or :class:`firedrake.ufl_expr.TrialFunction`\s.
+
+    :arg F: the 0-form
+    :return: the corresponding error indicator field
     """
     if not isinstance(F, ufl.form.Form):
         raise TypeError(f"Expected 'F' to be a Form, not '{type(F)}'.")
@@ -110,15 +116,21 @@ def indicators2estimator(
 def get_dwr_indicator(
     F, adjoint_error: Function, test_space: Optional[Union[WithGeometry, Dict]] = None
 ) -> Function:
-    """
-    Generate a dual weighted residual (DWR) error indicator, given a form and an
-    approximation of the error in the adjoint solution.
+    r"""
+    Given a 1-form and an approximation of the error in the adjoint solution, compute a
+    dual weighted residual (DWR) error indicator.
+
+    Note that each term of a 1-form contains only one
+    :class:`firedrake.ufl_expr.TestFunction`. The 1-form most commonly corresponds to the
+    variational form of a PDE. If the PDE is linear, it should be written as in the
+    nonlinear case (i.e., with the solution field in place of any
+    :class:`firedrake.ufl_expr.TrialFunction`\s.
 
     :arg F: the form
     :arg adjoint_error: the approximation to the adjoint error, either as a single
         :class:`firedrake.function.Function`, or in a dictionary
     :kwarg test_space: the
-        :class:`firedrake.functionspaceimpl.FunctionSpace` that the test function lives
+        :class:`firedrake.functionspaceimpl.WithGeometry` that the test function lives
         in, or an appropriate dictionary
     """
     mapping = {}

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -112,7 +112,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         enrichment_kwargs: dict = {},
         adj_kwargs: dict = {},
         indicator_fn: Callable = get_dwr_indicator,
-    ) -> Tuple[dict, list]:
+    ) -> Tuple[dict, AttrDict]:
         """
         Compute goal-oriented error indicators for each
         subinterval based on solving the adjoint problem
@@ -145,7 +145,9 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 field: [
                     [
                         Function(fs, name=f"{field}_error_indicator")
-                        for _ in range(self.time_partition.exports_per_subinterval[i] - 1)
+                        for _ in range(
+                            self.time_partition.exports_per_subinterval[i] - 1
+                        )
                     ]
                     for i, fs in enumerate(P0_spaces)
                 ]
@@ -193,7 +195,6 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
 
                 # Loop over each strongly coupled field
                 for f in self.fields:
-
                     # Update fields
                     transfer(sols[f][FWD][i][j], u[f])
                     transfer(sols[f][FWD_OLD][i][j], u_[f])

--- a/test/test_error_estimation.py
+++ b/test/test_error_estimation.py
@@ -1,5 +1,6 @@
 from firedrake import *
-from pyroteus.error_estimation import form2indicator
+from pyroteus.error_estimation import form2indicator, indicators2estimator
+from pyroteus.time_partition import TimeInstant, TimePartition
 import unittest
 
 
@@ -39,6 +40,119 @@ class TestForm2Indicator(unittest.TestCase):
         indicator = form2indicator(F)
         self.assertAlmostEqual(indicator.dat.data[0], 0)
         self.assertAlmostEqual(indicator.dat.data[1], 0.5)
+
+
+class TestIndicators2Estimator(unittest.TestCase):
+    """
+    Unit tests for :func:`indicators2estimator`.
+    """
+
+    def setUp(self):
+        self.mesh = UnitSquareMesh(1, 1)
+        self.fs = FunctionSpace(self.mesh, "CG", 1)
+        self.trial = TrialFunction(self.fs)
+        self.test = TestFunction(self.fs)
+        self.one = Function(self.fs).assign(1)
+
+    def test_indicators_type_error1(self):
+        time_instant = TimeInstant("field")
+        with self.assertRaises(TypeError) as cm:
+            indicators2estimator(self.one, time_instant)
+        msg = (
+            "Expected 'indicators' to be a dict, not"
+            " '<class 'firedrake.function.Function'>'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_indicators_type_error2(self):
+        time_instant = TimeInstant("field")
+        with self.assertRaises(TypeError) as cm:
+            indicators2estimator({"field": self.one}, time_instant)
+        msg = (
+            "Expected values of 'indicators' to be iterables, not"
+            " '<class 'firedrake.function.Function'>'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_indicators_type_error3(self):
+        time_instant = TimeInstant("field")
+        with self.assertRaises(TypeError) as cm:
+            indicators2estimator({"field": 1}, time_instant)
+        msg = "Expected values of 'indicators' to be iterables, not '<class 'int'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_indicators_type_error4(self):
+        time_instant = TimeInstant("field")
+        with self.assertRaises(TypeError) as cm:
+            indicators2estimator({"field": [self.one]}, time_instant)
+        msg = (
+            "Expected entries of 'indicators' to be iterables, not"
+            " '<class 'firedrake.function.Function'>'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_indicators_type_error5(self):
+        time_instant = TimeInstant("field")
+        with self.assertRaises(TypeError) as cm:
+            indicators2estimator({"field": [1]}, time_instant)
+        msg = "Expected entries of 'indicators' to be iterables, not '<class 'int'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_time_partition_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            indicators2estimator({"field": [self.one]}, 1.0)
+        msg = "Expected 'time_partition' to be a TimePartition, not '<class 'float'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_time_partition_wrong_field_error(self):
+        time_instant = TimeInstant("field")
+        with self.assertRaises(ValueError) as cm:
+            indicators2estimator({"f": [[self.one]]}, time_instant)
+        msg = "Key 'f' does not exist in the TimePartition provided."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_absolute_value_type_error(self):
+        time_instant = TimeInstant("field")
+        with self.assertRaises(TypeError) as cm:
+            indicators2estimator(
+                {"field": [[self.one]]}, time_instant, absolute_value=0
+            )
+        msg = "Expected 'absolute_value' to be a bool, not '<class 'int'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_unit_time_instant(self):
+        time_instant = TimeInstant("field", time=1.0)
+        indicator = form2indicator(self.one * dx)
+        estimator = indicators2estimator({"field": [[indicator]]}, time_instant)
+        self.assertAlmostEqual(estimator, 1.0)
+
+    def test_half_time_instant(self):
+        time_instant = TimeInstant("field", time=0.5)
+        indicator = form2indicator(self.one * dx)
+        estimator = indicators2estimator({"field": [[indicator]]}, time_instant)
+        self.assertAlmostEqual(estimator, 0.5)
+
+    def test_time_partition_same_timestep(self):
+        time_partition = TimePartition(1.0, 2, [0.5, 0.5], ["field"])
+        indicator = form2indicator(self.one * dx)
+        estimator = indicators2estimator({"field": [2 * [indicator]]}, time_partition)
+        self.assertAlmostEqual(estimator, 1.0)
+
+    def test_time_partition_different_timesteps(self):
+        time_partition = TimePartition(1.0, 2, [0.5, 0.25], ["field"])
+        indicator = form2indicator(self.one * dx)
+        estimator = indicators2estimator(
+            {"field": [[indicator], 2 * [indicator]]}, time_partition
+        )
+        self.assertAlmostEqual(estimator, 1.0)
+
+    def test_time_instant_multiple_fields(self):
+        time_instant = TimeInstant(["field1", "field2"], time=1.0)
+        indicator = form2indicator(self.one * dx)
+        estimator = indicators2estimator(
+            {"field1": [[indicator]], "field2": [[indicator]]}, time_instant
+        )
+        self.assertAlmostEqual(estimator, 2.0)
 
 
 if __name__ == "__main__":

--- a/test/test_error_estimation.py
+++ b/test/test_error_estimation.py
@@ -1,0 +1,45 @@
+from firedrake import *
+from pyroteus.error_estimation import form2indicator
+import unittest
+
+
+class TestForm2Indicator(unittest.TestCase):
+    """
+    Unit tests for :func:`form2indicator`.
+    """
+
+    def setUp(self):
+        self.mesh = UnitSquareMesh(1, 1)
+        self.fs = FunctionSpace(self.mesh, "CG", 1)
+        self.trial = TrialFunction(self.fs)
+        self.test = TestFunction(self.fs)
+        self.one = Function(self.fs).assign(1)
+
+    def test_form_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            form2indicator(1)
+        msg = "Expected 'F' to be a Form, not '<class 'int'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_exterior_facet_integral(self):
+        F = self.one * ds(1) - self.one * ds(2)
+        indicator = form2indicator(F)
+        self.assertAlmostEqual(indicator.dat.data[0], -2)
+        self.assertAlmostEqual(indicator.dat.data[1], 2)
+
+    def test_interior_facet_integral(self):
+        F = avg(self.one) * dS
+        indicator = form2indicator(F)
+        self.assertAlmostEqual(indicator.dat.data[0], 2 * sqrt(2))
+        self.assertAlmostEqual(indicator.dat.data[1], 2 * sqrt(2))
+
+    def test_cell_integral(self):
+        x, y = SpatialCoordinate(self.mesh)
+        F = conditional(x + y < 1, 1, 0) * dx
+        indicator = form2indicator(F)
+        self.assertAlmostEqual(indicator.dat.data[0], 0)
+        self.assertAlmostEqual(indicator.dat.data[1], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
I'm making an effort to improve the test coverage across Pyroteus and hopefully improving its robustness in the process. Here are some tweaks to the error estimation code, plus unit tests.

Partially addresses #77.