### PR TITLE
Add unit tests for Bessel functions and orthogonalisation

### DIFF
--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -95,6 +95,7 @@ class AdjointMeshSeq(MeshSeq):
         self.J = 0
         self.controls = None
         self.qoi_values = []
+        self.fp_iteration = 0
 
     @property
     @pyadjoint.no_annotations
@@ -294,7 +295,6 @@ class AdjointMeshSeq(MeshSeq):
 
             # Loop over prognostic variables
             for field, fs in function_spaces.items():
-
                 # Get solve blocks
                 solve_blocks = self.get_solve_blocks(field, subinterval=i)
                 num_solve_blocks = len(solve_blocks)
@@ -332,7 +332,6 @@ class AdjointMeshSeq(MeshSeq):
                         f" ({len(solve_blocks[::stride])} > {num_exports-1})"
                     )
                 for j, block in zip(range(num_exports - 1), solve_blocks[::stride]):
-
                     # Lagged forward solution and adjoint values
                     if fwd_old_idx is not None:
                         dep = block._dependencies[fwd_old_idx]

--- a/pyroteus/math.py
+++ b/pyroteus/math.py
@@ -1,5 +1,6 @@
 import numpy as np
 import ufl
+import ufl.core.expr
 
 
 __all__ = ["bessi0", "bessk0", "gram_schmidt", "construct_orthonormal_basis"]
@@ -30,14 +31,18 @@ def bessi0(x):
     Code taken from :cite:`VVP+:92`.
     """
     if isinstance(x, np.ndarray):
-        from numpy import abs, exp, sqrt
-
         if np.isclose(x, 0).any():
             raise ValueError("Cannot divide by zero.")
+        exp = np.exp
+        sqrt = np.sqrt
+        ax = np.abs(x)
     else:
-        from ufl import abs, exp, sqrt
+        if not isinstance(x, ufl.core.expr.Expr):
+            raise TypeError(f"Expected UFL Expr, not '{type(x)}'.")
+        exp = ufl.exp
+        sqrt = ufl.sqrt
+        ax = ufl.as_ufl(abs(x))
 
-    ax = abs(x)
     x1 = (x / 3.75) ** 2
     coeffs1 = (
         1.0,
@@ -77,14 +82,19 @@ def bessk0(x):
     Code taken from :cite:`VVP+:92`.
     """
     if isinstance(x, np.ndarray):
-        from numpy import log as ln
-        from numpy import exp, sqrt, where
-
         if (x <= 0).any():
             raise ValueError("Cannot take the logarithm of a non-positive number.")
+        ln = np.log
+        exp = np.exp
+        sqrt = np.sqrt
+        where = np.where
     else:
-        from ufl import exp, ln, sqrt
-        from ufl import conditional as where
+        if not isinstance(x, ufl.core.expr.Expr):
+            raise TypeError(f"Expected UFL Expr, not '{type(x)}'.")
+        ln = ufl.ln
+        exp = ufl.exp
+        sqrt = ufl.sqrt
+        where = ufl.conditional
 
     x1 = x * x / 4.0
     coeffs1 = (

--- a/pyroteus/math.py
+++ b/pyroteus/math.py
@@ -111,29 +111,42 @@ def bessk0(x):
     return where(x <= 2, expr1, expr2)
 
 
-def gram_schmidt(*v, normalise=False):
+def gram_schmidt(*vectors, normalise=False):
     """
     Given some vectors, construct an orthogonal basis
     using Gram-Schmidt orthogonalisation.
 
-    :args v: the vectors to orthogonalise
+    :args vectors: the vectors to orthogonalise
     :kwargs normalise: do we want an orthonormal basis?
     """
-    if isinstance(v[0], np.ndarray):
+    if isinstance(vectors[0], np.ndarray):
         from numpy import dot, sqrt
+
+        # Check that vector types match
+        for i, vi in enumerate(vectors[1:]):
+            if not isinstance(vi, type(vectors[0])):
+                raise TypeError(
+                    f"Inconsistent vector types: '{type(vectors[0])}' vs. '{type(vi)}'."
+                )
     else:
         from ufl import dot, sqrt
-    u = []
+
+        # TODO: Check that valid UFL types are used
 
     def proj(x, y):
         return dot(x, y) / dot(x, x) * x
 
-    for i, vi in enumerate(v):
+    # Apply Gram-Schmidt algorithm
+    u = []
+    for i, vi in enumerate(vectors):
         if i > 0:
             vi -= sum([proj(uj, vi) for uj in u])
         u.append(vi / sqrt(dot(vi, vi)) if normalise else vi)
-    if isinstance(v[0], np.ndarray):
+
+    # Ensure consistency of outputs
+    if isinstance(vectors[0], np.ndarray):
         u = [np.array(ui) for ui in u]
+
     return u
 
 

--- a/pyroteus/math.py
+++ b/pyroteus/math.py
@@ -5,11 +5,22 @@ import ufl
 __all__ = ["bessi0", "bessk0", "gram_schmidt", "construct_orthonormal_basis"]
 
 
-def _recurse(a, *val):
-    out = val[0]
-    if len(val) > 1:
-        out += a * _recurse(*val[1:])
-    return out
+def recursive_polynomial(x, coeffs):
+    r"""
+    Compute the polynomial
+
+    ..math::
+        a_0 + x (a_1 + x (a_2 + \dots + x a_n)),
+
+    with coefficients :math:`a_0,\dots,a_n` in a recursive manner.
+
+    :arg x: value at which to evaluate the polynomial
+    :arg coeffs: tuple of coefficients defining the polynomial
+    """
+    p = coeffs[0]
+    if len(coeffs) > 1:
+        p += x * recursive_polynomial(x, coeffs[1:])
+    return p
 
 
 def bessi0(x):
@@ -18,9 +29,17 @@ def bessi0(x):
 
     Code taken from :cite:`VVP+:92`.
     """
+    if isinstance(x, np.ndarray):
+        from numpy import abs, exp, sqrt
+
+        if np.isclose(x, 0).any():
+            raise ValueError("Cannot divide by zero.")
+    else:
+        from ufl import abs, exp, sqrt
+
     ax = abs(x)
-    expr1 = _recurse(
-        (x / 3.75) ** 2,
+    x1 = (x / 3.75) ** 2
+    coeffs1 = (
         1.0,
         3.5156229,
         3.0899424,
@@ -29,23 +48,26 @@ def bessi0(x):
         3.60768e-2,
         4.5813e-3,
     )
-    expr2 = (
-        ufl.exp(ax)
-        / ufl.sqrt(ax)
-        * _recurse(
-            3.75 / ax,
-            0.39894228,
-            1.328592e-2,
-            2.25319e-3,
-            -1.57565e-3,
-            9.16281e-3,
-            -2.057706e-2,
-            2.635537e-2,
-            -1.647633e-2,
-            3.92377e-3,
-        )
+    x2 = 3.75 / ax
+    coeffs2 = (
+        0.39894228,
+        1.328592e-2,
+        2.25319e-3,
+        -1.57565e-3,
+        9.16281e-3,
+        -2.057706e-2,
+        2.635537e-2,
+        -1.647633e-2,
+        3.92377e-3,
     )
-    return ufl.conditional(ax < 3.75, expr1, expr2)
+
+    expr1 = recursive_polynomial(x1, coeffs1)
+    expr2 = exp(ax) / sqrt(ax) * recursive_polynomial(x2, coeffs2)
+
+    if isinstance(x, np.ndarray):
+        return np.where(ax < 3.75, expr1, expr2)
+    else:
+        return ufl.conditional(ax < 3.75, expr1, expr2)
 
 
 def bessk0(x):
@@ -54,9 +76,18 @@ def bessk0(x):
 
     Code taken from :cite:`VVP+:92`.
     """
-    expr1 = -ufl.ln(x / 2.0) * bessi0(x)
-    expr1 += _recurse(
-        x * x / 4.0,
+    if isinstance(x, np.ndarray):
+        from numpy import log as ln
+        from numpy import exp, sqrt, where
+
+        if (x <= 0).any():
+            raise ValueError("Cannot take the logarithm of a non-positive number.")
+    else:
+        from ufl import exp, ln, sqrt
+        from ufl import conditional as where
+
+    x1 = x * x / 4.0
+    coeffs1 = (
         -0.57721566,
         0.42278420,
         0.23069756,
@@ -65,21 +96,19 @@ def bessk0(x):
         1.0750e-4,
         7.4e-6,
     )
-    expr2 = (
-        ufl.exp(-x)
-        / ufl.sqrt(x)
-        * _recurse(
-            2.0 / x,
-            1.25331414,
-            -7.832358e-2,
-            2.189568e-2,
-            -1.062446e-2,
-            5.87872e-3,
-            -2.51540e-3,
-            5.3208e-4,
-        )
+    x2 = 2.0 / x
+    coeffs2 = (
+        1.25331414,
+        -7.832358e-2,
+        2.189568e-2,
+        -1.062446e-2,
+        5.87872e-3,
+        -2.51540e-3,
+        5.3208e-4,
     )
-    return ufl.conditional(x > 2, expr2, expr1)
+    expr1 = -ln(x / 2.0) * bessi0(x) + recursive_polynomial(x1, coeffs1)
+    expr2 = exp(-x) / sqrt(x) * recursive_polynomial(x2, coeffs2)
+    return where(x <= 2, expr1, expr2)
 
 
 def gram_schmidt(*v, normalise=False):

--- a/pyroteus/math.py
+++ b/pyroteus/math.py
@@ -179,13 +179,11 @@ def construct_basis(vector, normalise=True):
             )
         as_vector = np.array
         dim = vector.shape[0]
-        dot = np.dot
     else:
         if not isinstance(vector, ufl.core.expr.Expr):
             raise TypeError(f"Expected UFL Expr, not '{type(vector)}'.")
         as_vector = ufl.as_vector
         dim = ufl.domain.extract_unique_domain(vector).topological_dimension()
-        dot = ufl.dot
 
     if dim not in (2, 3):
         raise ValueError(f"Dimension {dim} not supported.")

--- a/pyroteus/recovery.py
+++ b/pyroteus/recovery.py
@@ -161,7 +161,7 @@ def recover_boundary_hessian(
         :func:`firedrake.functionspace.TensorFunctionSpace`
         in which the metric will exist
     """
-    from pyroteus.math import construct_orthonormal_basis
+    from pyroteus.math import construct_basis
     from pyroteus.metric import get_metric_kernel
 
     d = mesh.topological_dimension()
@@ -169,8 +169,9 @@ def recover_boundary_hessian(
 
     # Apply Gram-Schmidt to get tangent vectors
     n = ufl.FacetNormal(mesh)
-    s = construct_orthonormal_basis(n)
-    ns = ufl.as_vector([n, *s])
+    ns = construct_basis(n)
+    s = ns[1:]
+    ns = ufl.as_vector(ns)
 
     # Setup
     P1 = FunctionSpace(mesh, "CG", 1)
@@ -191,7 +192,6 @@ def recover_boundary_hessian(
     }
 
     if method.upper() == "L2":
-
         # Arbitrary value on domain interior
         a = v * Hs * ufl.dx
         L = v * h * ufl.dx

--- a/test/test_math.py
+++ b/test/test_math.py
@@ -1,11 +1,5 @@
 from firedrake import UnitTriangleMesh
-from pyroteus.math import (
-    bessk0,
-    bessi0,
-    construct_basis,
-    gram_schmidt,
-    recursive_polynomial,
-)
+from pyroteus.math import *
 import numpy as np
 from parameterized import parameterized
 import scipy as sp
@@ -17,24 +11,6 @@ class TestBessel(unittest.TestCase):
     """
     Unit tests for Bessel functions.
     """
-
-    @parameterized.expand([1, 2, 3, (np.array([1, 2]),)])
-    def test_recursive_polynomial0(self, a):
-        x0 = 1
-        p = recursive_polynomial(a, (x0,))
-        self.assertEqual(p, x0)
-
-    @parameterized.expand([1, 2, 3, (np.array([1, 2]),)])
-    def test_recursive_polynomial1(self, a):
-        x0, x1 = 1, -1
-        p = recursive_polynomial(a, (x0, x1))
-        self.assertTrue(np.allclose(p, x0 + a * x1))
-
-    @parameterized.expand([1, 2, 3, (np.array([1, 2]),)])
-    def test_recursive_polynomial2(self, a):
-        x0, x1, x2 = 1, -1, 1
-        p = recursive_polynomial(a, (x0, x1, x2))
-        self.assertTrue(np.allclose(p, x0 + a * (x1 + a * x2)))
 
     def test_bessi0_numpy_divbyzero_error(self):
         with self.assertRaises(ValueError) as cm:

--- a/test/test_math.py
+++ b/test/test_math.py
@@ -1,6 +1,65 @@
-from pyroteus.math import gram_schmidt
+from pyroteus.math import bessk0, bessi0, recursive_polynomial, gram_schmidt
 import numpy as np
+from parameterized import parameterized
 import pytest
+import scipy as sp
+import unittest
+
+
+class TestBessel(unittest.TestCase):
+    """
+    Unit tests for Bessel functions.
+    """
+
+    @parameterized.expand([1, 2, 3, (np.array([1, 2]),)])
+    def test_recursive_polynomial0(self, a):
+        x0 = 1
+        p = recursive_polynomial(a, (x0,))
+        self.assertEqual(p, x0)
+
+    @parameterized.expand([1, 2, 3, (np.array([1, 2]),)])
+    def test_recursive_polynomial1(self, a):
+        x0, x1 = 1, -1
+        p = recursive_polynomial(a, (x0, x1))
+        self.assertTrue(np.allclose(p, x0 + a * x1))
+
+    @parameterized.expand([1, 2, 3, (np.array([1, 2]),)])
+    def test_recursive_polynomial2(self, a):
+        x0, x1, x2 = 1, -1, 1
+        p = recursive_polynomial(a, (x0, x1, x2))
+        self.assertTrue(np.allclose(p, x0 + a * (x1 + a * x2)))
+
+    def test_bessi0_numpy_divbyzero_error(self):
+        with self.assertRaises(ValueError) as cm:
+            bessi0(np.array([1, 0]))
+        msg = "Cannot divide by zero."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_bessi0_ufl_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            bessi0(UnitTriangleMesh())
+        msg = "Expected UFL Expr, not '<class 'firedrake.mesh.MeshGeometry'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_bessi0_numpy(self):
+        x = np.array([1, 2, 3])
+        self.assertTrue(np.allclose(bessi0(x), sp.special.i0(x)))
+
+    def test_bessk0_numpy_nonpositive_error(self):
+        with self.assertRaises(ValueError) as cm:
+            bessk0(np.array([1, -1]))
+        msg = "Cannot take the logarithm of a non-positive number."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_bessk0_ufl_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            bessk0(UnitTriangleMesh())
+        msg = "Expected UFL Expr, not '<class 'firedrake.mesh.MeshGeometry'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_bessk0_numpy(self):
+        x = np.array([1, 2, 3])
+        self.assertTrue(np.allclose(bessk0(x), sp.special.k0(x)))
 
 
 @pytest.fixture(params=[2, 3])

--- a/test/test_math.py
+++ b/test/test_math.py
@@ -1,8 +1,15 @@
-from pyroteus.math import bessk0, bessi0, recursive_polynomial, gram_schmidt
+from firedrake import UnitTriangleMesh
+from pyroteus.math import (
+    bessk0,
+    bessi0,
+    construct_basis,
+    gram_schmidt,
+    recursive_polynomial,
+)
 import numpy as np
 from parameterized import parameterized
-import pytest
 import scipy as sp
+import ufl
 import unittest
 
 
@@ -62,27 +69,75 @@ class TestBessel(unittest.TestCase):
         self.assertTrue(np.allclose(bessk0(x), sp.special.k0(x)))
 
 
-@pytest.fixture(params=[2, 3])
-def dim(request):
-    return request.param
-
-
-@pytest.fixture(params=[True, False])
-def normalise(request):
-    return request.param
-
-
-def test_gram_schmidt_numpy(dim, normalise):
+class TestOrthogonalisation(unittest.TestCase):
     """
-    Apply Gram-Schmidt to a random set of
-    vectors and check that the result is
-    an orthogonal/orthonormal set.
+    Unit tests for orthogonalisation.
     """
-    np.random.seed(0)
-    v = [np.random.rand(dim) for i in range(dim)]
-    u = gram_schmidt(*v, normalise=True)
-    for i, ui in enumerate(u):
-        for j, uj in enumerate(u):
-            if not normalise and i == j:
-                continue
-            assert np.isclose(np.dot(ui, uj), 1.0 if i == j else 0.0)
+
+    def setUp(self):
+        np.random.seed(0)
+
+    def test_gram_schmidt_type_error_numpy(self):
+        with self.assertRaises(TypeError) as cm:
+            gram_schmidt(np.ones(2), [1, 2])
+        msg = (
+            "Inconsistent vector types:"
+            " '<class 'numpy.ndarray'>' vs. '<class 'list'>'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_gram_schmidt_type_error_ufl(self):
+        x = ufl.SpatialCoordinate(UnitTriangleMesh())
+        with self.assertRaises(TypeError) as cm:
+            gram_schmidt(x, [1, 2])
+        msg = (
+            "Inconsistent vector types:"
+            " '<class 'ufl.core.expr.Expr'>' vs. '<class 'list'>'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    @parameterized.expand([2, 3])
+    def test_gram_schmidt_orthonormal_numpy(self, dim):
+        v = np.random.rand(dim, dim)
+        u = np.array(gram_schmidt(*v, normalise=True))
+        self.assertTrue(np.allclose(u.transpose() @ u, np.eye(dim)))
+
+    @parameterized.expand([2, 3])
+    def test_gram_schmidt_nonorthonormal_numpy(self, dim):
+        v = np.random.rand(dim, dim)
+        u = gram_schmidt(*v, normalise=False)
+        for i, ui in enumerate(u):
+            for j, uj in enumerate(u):
+                if i != j:
+                    self.assertAlmostEqual(np.dot(ui, uj), 0)
+
+    def test_basis_shape_error_numpy(self):
+        with self.assertRaises(ValueError) as cm:
+            construct_basis(np.ones((1, 2)))
+        msg = "Expected a vector, got an array of shape (1, 2)."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_basis_dim_error_numpy(self):
+        with self.assertRaises(ValueError) as cm:
+            construct_basis(np.ones(0))
+        msg = "Dimension 0 not supported."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_basis_ufl_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            construct_basis(UnitTriangleMesh())
+        msg = "Expected UFL Expr, not '<class 'firedrake.mesh.MeshGeometry'>'."
+        self.assertEqual(str(cm.exception), msg)
+
+    @parameterized.expand([2, 3])
+    def test_basis_orthonormal_numpy(self, dim):
+        u = np.array(construct_basis(np.random.rand(dim), normalise=True))
+        self.assertTrue(np.allclose(u.transpose() @ u, np.eye(dim)))
+
+    @parameterized.expand([2, 3])
+    def test_basis_orthogonal_numpy(self, dim):
+        u = construct_basis(np.random.rand(dim), normalise=False)
+        for i, ui in enumerate(u):
+            for j, uj in enumerate(u):
+                if i != j:
+                    self.assertAlmostEqual(np.dot(ui, uj), 0)

--- a/test/test_recovery.py
+++ b/test/test_recovery.py
@@ -161,8 +161,7 @@ class TestRecoveryBowl(unittest.TestCase):
         H = recover_boundary_hessian(f, mesh, method="L2")
 
         # Check its directional derivatives in boundaries are zero
-        S = construct_orthonormal_basis(FacetNormal(mesh))
-        for s in S:
+        for s in construct_basis(FacetNormal(mesh))[1:]:
             dHds = abs(assemble(dot(div(H), s) * ds))
             assert dHds < 2.0e-08, "Non-zero tangential derivative"
 
@@ -176,8 +175,7 @@ class TestRecoveryBowl(unittest.TestCase):
         H = recover_boundary_hessian(f, mesh, method="Clement")
 
         # Check its directional derivatives in boundaries are zero
-        S = construct_orthonormal_basis(FacetNormal(mesh))
-        for s in S:
+        for s in construct_basis(FacetNormal(mesh))[1:]:
             dHds = abs(assemble(dot(div(H), s) * ds))
             assert dHds < 2.0e-08, "Non-zero tangential derivative"
 


### PR DESCRIPTION
This PR adds unit tests for the Bessel function and orthogonalisation utilities in `math.py`.

Note that there was a bug in how the Bessel functions, which possibly gave incorrect representation of the point source in the `point_discharge` demos. (Not sure whether you had any problems with the source term when using the demo, @ddundo?) The fix is confirmed by testing against the SciPy implementations.

Partially addresses #77.