### PR TITLE
Add unit tests for interpolation and recovery

### DIFF
--- a/pyroteus/interpolation.py
+++ b/pyroteus/interpolation.py
@@ -179,9 +179,9 @@ def project(
         target = Function(Vt)
 
     # Account for the case where the meshes match
-    Hs = ufl.domain.extract_unique_domain(source)
-    Ht = ufl.domain.extract_unique_domain(target)
-    if Hs == Ht:
+    source_mesh = ufl.domain.extract_unique_domain(source)
+    target_mesh = ufl.domain.extract_unique_domain(target)
+    if source_mesh == target_mesh:
         if Vs == Vt:
             return target.assign(source)
         elif not adjoint:

--- a/pyroteus/interpolation.py
+++ b/pyroteus/interpolation.py
@@ -79,7 +79,7 @@ def clement_interpolant(
         domain = "{[i]: 0 <= i < patch.dofs}"
         instructions = "patch[i] = patch[i] + vol[0]"
         keys = {"vol": (volume, op2.READ), "patch": (patch_volume, op2.RW)}
-        firedrake.par_loop((domain, instructions), dX, keys, is_loopy_kernel=True)
+        firedrake.par_loop((domain, instructions), dX, keys)
 
         # Take weighted average
         if rank == 0:
@@ -93,7 +93,7 @@ def clement_interpolant(
             "v": (volume, op2.READ),
             "t": (target, op2.RW),
         }
-        firedrake.par_loop((tdomain, instructions), dX, keys, is_loopy_kernel=True)
+        firedrake.par_loop((tdomain, instructions), dX, keys)
     else:
         dX = ufl.ds(domain=mesh)
 
@@ -119,7 +119,7 @@ def clement_interpolant(
             "indicator": (bnd_indicator, op2.READ),
             "patch": (patch_volume, op2.RW),
         }
-        firedrake.par_loop((domain, instructions), dX, keys, is_loopy_kernel=True)
+        firedrake.par_loop((domain, instructions), dX, keys)
 
         # Take weighted average
         if rank == 0:
@@ -134,7 +134,7 @@ def clement_interpolant(
             "b": (bnd_indicator, op2.READ),
             "t": (target, op2.RW),
         }
-        firedrake.par_loop((tdomain, instructions), dX, keys, is_loopy_kernel=True)
+        firedrake.par_loop((tdomain, instructions), dX, keys)
 
     # Divide by patch volume and ensure finite
     target.interpolate(target / patch_volume)

--- a/pyroteus/interpolation.py
+++ b/pyroteus/interpolation.py
@@ -144,10 +144,6 @@ def clement_interpolant(
     return target
 
 
-# --- Linear interpolation
-
-# TODO
-
 # --- Conservative interpolation by supermesh projection
 
 
@@ -156,7 +152,7 @@ def project(
     target_space: Union[FunctionSpace, Function],
     adjoint: bool = False,
     **kwargs,
-) -> Function:  # TODO: Add unit tests
+) -> Function:
     """
     Overload :func:`firedrake.projection.project` to account for the case of two mixed
     function spaces defined on different meshes and for the adjoint projection operator.

--- a/pyroteus/recovery.py
+++ b/pyroteus/recovery.py
@@ -40,15 +40,18 @@ def double_clement(f: Function):
 
     :arg f: the scalar field whose derivatives we seek to recover
     """
-    msg = "Clement can only be used to compute gradients of"
     if not isinstance(f, Function):
-        raise ValueError(f"{msg} Functions.")
+        raise ValueError(
+            "Clement interpolation can only be used to compute gradients of"
+            " Lagrange Functions of degree > 0."
+        )
     family = f.ufl_element().family()
     degree = f.ufl_element().degree()
-    if family not in ("Lagrange", "Discontinuous Lagrange"):
-        raise ValueError(f"{msg} Lagrange fields.")
-    if degree == 0:
-        raise ValueError(f"{msg} fields of degree > 0.")
+    if family not in ("Lagrange", "Discontinuous Lagrange") or degree == 0:
+        raise ValueError(
+            "Clement interpolation can only be used to compute gradients of"
+            " Lagrange Functions of degree > 0."
+        )
     mesh = f.function_space().mesh()
 
     # Recover gradient

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -3,38 +3,194 @@ Test interpolation schemes.
 """
 from firedrake import *
 from pyroteus import *
-import pytest
-import numpy as np
+from parameterized import parameterized
+import unittest
 
 
-@pytest.fixture(params=["scalar", "vector", "tensor"])
-def shape(request):
-    return request.param
-
-
-def test_clement_interpolant(shape):
+class TestClement(unittest.TestCase):
     """
-    Check that volume averaging over two
-    elements gives the average at vertices
-    on the shared edge and the element-wise
-    values elsewhere.
-
-    :arg shape: choose from 'scalar', 'vector', 'tensor'
+    Unit tests for Clement interpolant.
     """
-    mesh = UnitSquareMesh(1, 1)
-    if shape == "scalar":
-        fs = FunctionSpace
-    elif shape == "vector":
-        fs = VectorFunctionSpace
-    elif shape == "tensor":
-        fs = TensorFunctionSpace
-    else:
-        raise ValueError(f"Shape '{shape} not recognised.")
-    P0 = fs(mesh, "DG", 0)
-    source = Function(P0)
-    source.dat.data[0] += 1.0
-    target = clement_interpolant(source)
-    assert np.allclose(target.dat.data[0], 0.5)
-    assert np.allclose(target.dat.data[1], 1.0)
-    assert np.allclose(target.dat.data[2], 0.5)
-    assert np.allclose(target.dat.data[3], 0.0)
+
+    def setUp(self):
+        n = 5
+        self.mesh = UnitSquareMesh(n, n)
+        self.P0 = FunctionSpace(self.mesh, "DG", 0)
+        self.P1 = FunctionSpace(self.mesh, "CG", 1)
+
+        h = 1 / n
+        self.x, self.y = SpatialCoordinate(self.mesh)
+        self.interior = conditional(
+            And(And(self.x > h, self.x < 1 - h), And(self.y > h, self.y < 1 - h)), 1, 0
+        )
+        self.boundary = 1 - self.interior
+        self.corner = conditional(
+            And(Or(self.x < h, self.x > 1 - h), Or(self.y < h, self.y > 1 - h)), 1, 0
+        )
+
+    def get_space(self, rank, family, degree):
+        if rank == 0:
+            return FunctionSpace(self.mesh, family, degree)
+        elif rank == 1:
+            return VectorFunctionSpace(self.mesh, family, degree)
+        else:
+            shape = tuple(rank * [self.mesh.topological_dimension()])
+            return TensorFunctionSpace(self.mesh, family, degree, shape=shape)
+
+    def analytic(self, rank):
+        if rank == 0:
+            return self.x
+        elif rank == 1:
+            return as_vector((self.x, self.y))
+        else:
+            return as_matrix([[self.x, self.y], [-self.y, -self.x]])
+
+    def test_rank_error(self):
+        with self.assertRaises(ValueError) as cm:
+            clement_interpolant(Function(self.get_space(3, "DG", 0)))
+        msg = "Rank-4 tensors are not supported."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_source_space_error(self):
+        with self.assertRaises(ValueError) as cm:
+            clement_interpolant(Function(self.get_space(0, "CG", 1)))
+        msg = "Source function provided must be from a P0 space."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_target_space_error(self):
+        with self.assertRaises(ValueError) as cm:
+            clement_interpolant(Function(self.P0), target_space=self.P0)
+        msg = "Target space provided must be P1."
+        self.assertEqual(str(cm.exception), msg)
+
+    @parameterized.expand([0, 1, 2])
+    def test_volume_average_2d(self, rank):
+        exact = self.analytic(rank)
+        P0 = self.get_space(rank, "DG", 0)
+        P1 = self.get_space(rank, "CG", 1)
+        source = Function(P0).project(exact)
+        target = clement_interpolant(source)
+        expected = Function(P1).interpolate(exact)
+        err = assemble(self.interior * (target - expected) ** 2 * dx)
+        self.assertAlmostEqual(err, 0)
+
+    @parameterized.expand([0, 1, 2])
+    def test_facet_average_2d(self, rank):
+        exact = self.analytic(rank)
+        P0 = self.get_space(rank, "DG", 0)
+        source = Function(P0).project(exact)
+        target = clement_interpolant(source, boundary=True)
+        expected = source
+        integrand = (1 - self.corner) * (target - expected) ** 2
+
+        # Check approximate recovery
+        for tag in [1, 2, 3, 4]:
+            self.assertLess(assemble(integrand * ds(tag)), 5e-3)
+
+
+class TestProject(unittest.TestCase):
+    """
+    Unit tests for mesh-to-mesh projection.
+    """
+
+    def setUp(self):
+        self.source_mesh = UnitSquareMesh(1, 1, diagonal="left")
+        self.target_mesh = UnitSquareMesh(1, 1, diagonal="right")
+
+    def sinusoid(self, source=True):
+        x, y = SpatialCoordinate(self.source_mesh if source else self.target_mesh)
+        return sin(pi * x) * sin(pi * y)
+
+    def test_notimplemented_error(self):
+        Vs = FunctionSpace(self.source_mesh, "CG", 1)
+        Vt = FunctionSpace(self.target_mesh, "CG", 1)
+        source = Function(Vs)
+        with self.assertRaises(NotImplementedError) as cm:
+            project(2 * source, Vt)
+        msg = "Can only currently project Functions."
+        self.assertEqual(str(cm.exception), msg)
+
+    @parameterized.expand([False, True])
+    def test_no_sub_source_space(self, adjoint):
+        Vs = FunctionSpace(self.source_mesh, "CG", 1)
+        Vt = FunctionSpace(self.target_mesh, "CG", 1)
+        Vt = Vt * Vt
+        with self.assertRaises(ValueError) as cm:
+            project(Function(Vs), Function(Vt), adjoint=adjoint)
+        if adjoint:
+            msg = "Source space has multiple components but target space does not."
+        else:
+            msg = "Target space has multiple components but source space does not."
+        self.assertEqual(str(cm.exception), msg)
+
+    @parameterized.expand([False, True])
+    def test_no_sub_target_space(self, adjoint):
+        Vs = FunctionSpace(self.source_mesh, "CG", 1)
+        Vt = FunctionSpace(self.target_mesh, "CG", 1)
+        Vs = Vs * Vs
+        with self.assertRaises(ValueError) as cm:
+            project(Function(Vs), Function(Vt), adjoint=adjoint)
+        if adjoint:
+            msg = "Target space has multiple components but source space does not."
+        else:
+            msg = "Source space has multiple components but target space does not."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_wrong_number_sub_spaces(self):
+        P1 = FunctionSpace(self.source_mesh, "CG", 1)
+        P0 = FunctionSpace(self.target_mesh, "DG", 0)
+        Vs = P1 * P1 * P1
+        Vt = P0 * P0
+        with self.assertRaises(ValueError) as cm:
+            project(Function(Vs), Function(Vt))
+        msg = "Inconsistent numbers of components in source and target spaces: 3 vs. 2."
+        self.assertEqual(str(cm.exception), msg)
+
+    @parameterized.expand([False, True])
+    def test_project_same_space(self, adjoint):
+        Vs = FunctionSpace(self.source_mesh, "CG", 1)
+        source = interpolate(self.sinusoid(), Vs)
+        target = Function(Vs)
+        project(source, target, adjoint=adjoint)
+        expected = source
+        self.assertAlmostEqual(errornorm(expected, target), 0)
+
+    @parameterized.expand([False, True])
+    def test_project_same_space_mixed(self, adjoint):
+        P1 = FunctionSpace(self.source_mesh, "CG", 1)
+        Vs = P1 * P1
+        source = Function(Vs)
+        s1, s2 = source.subfunctions
+        s1.interpolate(self.sinusoid())
+        s2.interpolate(-self.sinusoid())
+        target = Function(Vs)
+        project(source, target, adjoint=adjoint)
+        expected = source
+        self.assertAlmostEqual(errornorm(expected, target), 0)
+
+    def test_project_same_mesh(self):
+        Vs = FunctionSpace(self.source_mesh, "CG", 1)
+        Vt = FunctionSpace(self.source_mesh, "DG", 0)
+        source = interpolate(self.sinusoid(), Vs)
+        target = Function(Vt)
+        project(source, target, adjoint=adjoint)
+        expected = Function(Vt)
+        expected.project(source)
+        self.assertAlmostEqual(errornorm(expected, target), 0)
+
+    def test_project_same_mesh_mixed(self):
+        P1 = FunctionSpace(self.source_mesh, "CG", 1)
+        P0 = FunctionSpace(self.source_mesh, "DG", 0)
+        Vs = P1 * P1
+        Vt = P0 * P0
+        source = Function(Vs)
+        s1, s2 = source.subfunctions
+        s1.interpolate(self.sinusoid())
+        s2.interpolate(-self.sinusoid())
+        target = Function(Vt)
+        project(source, target, adjoint=adjoint)
+        expected = Function(Vt)
+        e1, e2 = expected.subfunctions
+        e1.project(s1)
+        e2.project(s2)
+        self.assertAlmostEqual(errornorm(expected, target), 0)

--- a/test/test_recovery.py
+++ b/test/test_recovery.py
@@ -26,9 +26,17 @@ class TestRecoverySetup(unittest.TestCase):
         V = FunctionSpace(self.mesh, family, degree)
         return Function(V).assign(1.0)
 
+    def test_clement_function_error(self):
+        f = bowl(*SpatialCoordinate(self.mesh))
+        kwargs = dict(method="Clement")
+        with self.assertRaises(ValueError) as cm:
+            recover_hessian(f, **kwargs)
+        msg = "Clement can only be used to compute gradients of Functions."
+        self.assertEqual(str(cm.exception), msg)
+
     def test_clement_space_error(self):
         f = self.get_func_ones("RT", 1)
-        kwargs = dict(method="Clement", mesh=self.mesh)
+        kwargs = dict(method="Clement")
         with self.assertRaises(ValueError) as cm:
             recover_hessian(f, **kwargs)
         msg = "Clement can only be used to compute gradients of Lagrange fields."
@@ -36,7 +44,7 @@ class TestRecoverySetup(unittest.TestCase):
 
     def test_clement_degree_error(self):
         f = self.get_func_ones("DG", 0)
-        kwargs = dict(method="Clement", mesh=self.mesh)
+        kwargs = dict(method="Clement")
         with self.assertRaises(ValueError) as cm:
             recover_hessian(f, **kwargs)
         msg = "Clement can only be used to compute gradients of fields of degree > 0."
@@ -44,7 +52,7 @@ class TestRecoverySetup(unittest.TestCase):
 
     def test_zz_notimplemented_error(self):
         f = self.get_func_ones("CG", 1)
-        kwargs = dict(method="ZZ", mesh=self.mesh)
+        kwargs = dict(method="ZZ")
         with self.assertRaises(NotImplementedError) as cm:
             recover_hessian(f, **kwargs)
         msg = "Zienkiewicz-Zhu recovery not yet implemented."
@@ -52,7 +60,7 @@ class TestRecoverySetup(unittest.TestCase):
 
     def test_unrecognised_interior_method_error(self):
         f = self.get_func_ones("CG", 1)
-        kwargs = dict(method="some_method", mesh=self.mesh)
+        kwargs = dict(method="some_method")
         with self.assertRaises(ValueError) as cm:
             recover_hessian(f, **kwargs)
         msg = "Recovery method 'some_method' not recognised."

--- a/test/test_recovery.py
+++ b/test/test_recovery.py
@@ -31,7 +31,10 @@ class TestRecoverySetup(unittest.TestCase):
         kwargs = dict(method="Clement")
         with self.assertRaises(ValueError) as cm:
             recover_hessian(f, **kwargs)
-        msg = "Clement can only be used to compute gradients of Functions."
+        msg = (
+            "Clement interpolation can only be used to compute gradients of"
+            " Lagrange Functions of degree > 0."
+        )
         self.assertEqual(str(cm.exception), msg)
 
     def test_clement_space_error(self):
@@ -39,7 +42,10 @@ class TestRecoverySetup(unittest.TestCase):
         kwargs = dict(method="Clement")
         with self.assertRaises(ValueError) as cm:
             recover_hessian(f, **kwargs)
-        msg = "Clement can only be used to compute gradients of Lagrange fields."
+        msg = (
+            "Clement interpolation can only be used to compute gradients of"
+            " Lagrange Functions of degree > 0."
+        )
         self.assertEqual(str(cm.exception), msg)
 
     def test_clement_degree_error(self):
@@ -47,7 +53,10 @@ class TestRecoverySetup(unittest.TestCase):
         kwargs = dict(method="Clement")
         with self.assertRaises(ValueError) as cm:
             recover_hessian(f, **kwargs)
-        msg = "Clement can only be used to compute gradients of fields of degree > 0."
+        msg = (
+            "Clement interpolation can only be used to compute gradients of"
+            " Lagrange Functions of degree > 0."
+        )
         self.assertEqual(str(cm.exception), msg)
 
     def test_zz_notimplemented_error(self):


### PR DESCRIPTION
This PR reworks the interpolation and recovery routines used in Pyroteus and adds unit tests.

Partially addresses #77.

Closes #89.