### PR TITLE
Add demo for 2D steady-state goal-oriented adaptation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Install Pyroteus
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          python -m pip uninstall pyroteus
+          python -m pip install -e .
       - name: Test Pyroteus
         run: |
           . /home/firedrake/firedrake/bin/activate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Pyroteus
         run: |
           . /home/firedrake/firedrake/bin/activate
-          python -m pip uninstall pyroteus
+          python -m pip uninstall -y pyroteus
           python -m pip install -e .
       - name: Test Pyroteus
         run: |

--- a/demos/point_discharge2d-goal_oriented.py
+++ b/demos/point_discharge2d-goal_oriented.py
@@ -1,0 +1,372 @@
+# Goal-oriented mesh adaptation for a 2D steady-state problem
+# ===========================================================
+#
+# In the `previous demo <./point_discharge2d-hessian.py.html>`__, we applied
+# Hessian-based mesh adaptation to the "point discharge with diffusion" steady-state 2D
+# test case. Here, we combine the goal-oriented error estimation approach from
+# `another previous demo <./point_discharge2d.py.html>`__ to provide the first
+# exposition of goal-oriented mesh adaptation in these demos.
+#
+# We copy over the setup as before. The only difference is that we import from
+# `pyroteus_adjoint` rather than `pyroteus`. ::
+
+from firedrake import *
+from firedrake.meshadapt import *
+from pyroteus_adjoint import *
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+from matplotlib import ticker
+
+
+fields = ["c"]
+
+
+def get_function_spaces(mesh):
+    return {"c": FunctionSpace(mesh, "CG", 1)}
+
+
+def source(mesh):
+    x, y = SpatialCoordinate(mesh)
+    x0, y0, r = 2, 5, 0.05606388
+    return 100.0 * exp(-((x - x0) ** 2 + (y - y0) ** 2) / r**2)
+
+
+def get_form(mesh_seq):
+    def form(index, sols):
+        c, c_ = sols["c"]
+        function_space = mesh_seq.function_spaces["c"][index]
+        D = Constant(0.1)
+        u = Constant(as_vector([1, 0]))
+        h = CellSize(mesh_seq[index])
+        S = source(mesh_seq[index])
+
+        # Stabilisation parameter
+        unorm = sqrt(dot(u, u))
+        tau = 0.5 * h / unorm
+        tau = min_value(tau, unorm * h / (6 * D))
+
+        # Setup variational problem
+        psi = TestFunction(function_space)
+        psi = psi + tau * dot(u, grad(psi))
+        F = (
+            dot(u, grad(c)) * psi * dx
+            + inner(D * grad(c), grad(psi)) * dx
+            - S * psi * dx
+        )
+        return {"c": F}
+
+    return form
+
+
+def get_bcs(mesh_seq):
+    def bcs(index):
+        function_space = mesh_seq.function_spaces["c"][index]
+        return DirichletBC(function_space, 0, 1)
+
+    return bcs
+
+
+def get_solver(mesh_seq):
+    def solver(index, ic):
+        function_space = mesh_seq.function_spaces["c"][index]
+
+        # Ensure dependence on the initial condition
+        c_ = Function(function_space, name="c_old")
+        c_.assign(ic["c"])
+        c = Function(function_space, name="c")
+        c.assign(c_)
+
+        # Setup variational problem
+        F = mesh_seq.form(index, {"c": (c, c_)})["c"]
+        bc = mesh_seq.bcs(index)
+
+        solve(F == 0, c, bcs=bc, ad_block_tag="c")
+        return {"c": c}
+
+    return solver
+
+
+def get_qoi(mesh_seq, sol, index):
+    def qoi():
+        c = sol["c"]
+        x, y = SpatialCoordinate(mesh_seq[index])
+        xr, yr, rr = 20, 7.5, 0.5
+        kernel = conditional((x - xr) ** 2 + (y - yr) ** 2 < rr**2, 1, 0)
+        return kernel * c * dx
+
+    return qoi
+
+
+# Since we want to do goal-oriented mesh adaptation, we use a
+# :class:`GoalOrientedMeshSeq`. In addition to the element count convergence criterion,
+# we add another relative tolerance condition for the change in QoI value between
+# iterations. ::
+
+params = GoalOrientedMetricParameters({"element_rtol": 0.005, "qoi_rtol": 0.005})
+
+mesh = RectangleMesh(50, 10, 50, 10)
+time_partition = TimeInstant(fields)
+mesh_seq = GoalOrientedMeshSeq(
+    time_partition,
+    mesh,
+    get_function_spaces=get_function_spaces,
+    get_form=get_form,
+    get_bcs=get_bcs,
+    get_solver=get_solver,
+    get_qoi=get_qoi,
+    qoi_type="steady",
+    parameters=params,
+)
+
+# Let's solve the adjoint problem on the initial mesh so that we can see what the
+# corresponding solution looks like. ::
+
+solutions = mesh_seq.solve_adjoint()
+plot_kwargs = {"levels": 50, "figsize": (10, 3), "cmap": "coolwarm"}
+interior_kw = {"linewidth": 0.5}
+fig, axes, tcs = plot_snapshots(
+    solutions,
+    time_partition,
+    "c",
+    "adjoint",
+    **plot_kwargs,
+)
+cbar = fig.colorbar(tcs[0][0], orientation="horizontal", pad=0.2)
+axes.set_title("Adjoint solution on initial mesh")
+fig.savefig("point_discharge2d-adjoint_init.jpg")
+plt.close()
+
+# .. figure:: point_discharge2d-mesh0.jpg
+#    :figwidth: 100%
+#    :align: center
+#
+# .. figure:: point_discharge2d-forward_init.jpg
+#    :figwidth: 80%
+#    :align: center
+#
+# .. figure:: point_discharge2d-adjoint_init.jpg
+#    :figwidth: 80%
+#    :align: center
+
+# The adaptor takes a different form in this case, depending on adjoint solution data
+# as well as forward solution data. For simplicity, we begin by using Pyroteus' inbuilt
+# isotropic metric function. ::
+
+
+def adaptor(mesh_seq, solutions, indicators):
+    # Deduce an isotropic metric from the error indicator field
+    metric = isotropic_metric(indicators["c"][0][0])
+
+    # Ramp the target metric complexity from 400 to 1000 over the first few iterations
+    base, target, iteration = 400, 1000, mesh_seq.fp_iteration
+    mp = {"dm_plex_metric_target_complexity": ramp_complexity(base, target, iteration)}
+    metric.set_parameters(mp)
+
+    # Normalise the metric according to the target complexity and then adapt the mesh
+    metric.normalise()
+    complexity = metric.complexity()
+    mesh_seq[0] = adapt(mesh_seq[0], metric)
+    num_dofs = mesh_seq.vertex_counts[-1][0]
+    num_elem = mesh_seq.element_counts[-1][0]
+    pyrint(
+        f"{iteration + 1:2d}, complexity: {complexity:4.0f}"
+        f", dofs: {num_dofs:4d}, elements: {num_elem:4d}"
+    )
+
+    # Plot each intermediate adapted mesh
+    fig, axes = plt.subplots(figsize=(10, 2))
+    mesh_seq.plot(fig=fig, axes=axes, interior_kw=interior_kw)
+    axes.set_title(f"Mesh at iteration {iteration + 1}")
+    fig.savefig(f"point_discharge2d-iso_go_mesh{iteration + 1}.jpg")
+    plt.close()
+
+    # Plot error indicator on intermediate meshes
+    plot_kwargs["norm"] = mcolors.LogNorm()
+    plot_kwargs["locator"] = ticker.LogLocator()
+    fig, axes, tcs = plot_indicator_snapshots(
+        indicators, time_partition, "c", **plot_kwargs
+    )
+    axes.set_title(f"Indicator at iteration {mesh_seq.fp_iteration + 1}")
+    fig.colorbar(tcs[0][0], orientation="horizontal", pad=0.2)
+    fig.savefig(f"point_discharge2d-iso_go_indicator{mesh_seq.fp_iteration + 1}.jpg")
+    plt.close()
+
+    # If the target complexity has not been reached, skip to the next iteration
+    return complexity < 0.95 * target
+
+
+# With the adaptor function defined, we can call the fixed point iteration method. Note
+# that, in addition to solving the forward problem, this version of the fixed point
+# iteration method solves the adjoint problem, as well as solving the forward problem
+# again on a globally uniformly refined mesh. The latter is particularly expensive, so
+# we should expect the computation to take more time. ::
+
+solutions = mesh_seq.fixed_point_iteration(adaptor)
+qoi_iso = mesh_seq.qoi_values
+dofs_iso = mesh_seq.vertex_counts
+
+# This time, we find that the fixed point iteration converges in five iterations.
+# Convergence is reached because the relative change in QoI is found to be smaller than
+# the default tolerance.
+#
+# .. code-block:: console
+#
+#     1, complexity:  371, dofs:  561, elements: 1000
+#     2, complexity:  588, dofs:  526, elements:  988
+#     3, complexity:  785, dofs:  729, elements: 1392
+#     4, complexity:  982, dofs:  916, elements: 1754
+#    Terminated due to QoI convergence after 5 iterations
+#
+# ::
+
+fig, axes = plt.subplots(figsize=(10, 2))
+mesh_seq.plot(fig=fig, axes=axes, interior_kw=interior_kw)
+axes.set_title("Adapted mesh")
+fig.savefig("point_discharge2d-iso_go_mesh.jpg")
+plt.close()
+
+plot_kwargs = {"levels": 50, "figsize": (10, 3), "cmap": "coolwarm"}
+fig, axes, tcs = plot_snapshots(
+    solutions,
+    time_partition,
+    "c",
+    "forward",
+    **plot_kwargs,
+)
+fig.colorbar(tcs[0][0], orientation="horizontal", pad=0.2)
+axes.set_title("Forward solution on adapted mesh")
+fig.savefig("point_discharge2d-forward_iso_go_adapted.jpg")
+plt.close()
+
+# .. figure:: point_discharge2d-iso_go_mesh.jpg
+#    :figwidth: 100%
+#    :align: center
+#
+# .. figure:: point_discharge2d-forward_iso_go_adapted.jpg
+#    :figwidth: 80%
+#    :align: center
+#
+# Looking at the final adapted mesh, we can make a few observations. Firstly, the mesh
+# elements are indeed isotropic. Secondly, there is clearly increased resolution
+# surrounding the point source, as well as the "receiver region" which the QoI integrates
+# over. There is also a band of increased resolution between these two regions. Finally,
+# the mesh has low resolution downstream of the receiver region. This is to be expected
+# because we have an advection-dominated problem, so the QoI value is independent of the
+# dynamics there.
+#
+# Pyroteus also provides drivers for *anisotropic* goal-oriented mesh adaptation. Here,
+# we consider the ``anisotropic_dwr_metric`` driver. (See documentation for details.) To
+# use it, we just need to define a different adaptor function. The same error indicator
+# is used as for the isotropic approach. In addition, the Hessian of the forward
+# solution is provided to give anisotropy to the metric.
+#
+# For this driver, normalisation is handled differently than for ``isotropic_metric``,
+# where the ``normalise`` method is called after construction. In this case, the metric
+# is already normalised within the call to ``anisotropic_dwr_metric``, so this is not
+# required. ::
+
+
+def adaptor(mesh_seq, solutions, indicators):
+    base, target, iteration = 400, 1000, mesh_seq.fp_iteration
+
+    # Deduce an anisotropic metric from the error indicator field and the Hessian of the
+    # forward solution
+    hessian = recover_hessian(solutions["c"]["forward"][0][0])
+    metric = anisotropic_metric(
+        indicators["c"][0][0],
+        hessian,
+        target_complexity=ramp_complexity(base, target, iteration),
+    )
+    complexity = metric.complexity()
+
+    # Adapt the mesh
+    mesh_seq[0] = adapt(mesh_seq[0], metric)
+    num_dofs = mesh_seq.vertex_counts[-1][0]
+    num_elem = mesh_seq.element_counts[-1][0]
+    pyrint(
+        f"{iteration + 1:2d}, complexity: {complexity:4.0f}"
+        f", dofs: {num_dofs:4d}, elements: {num_elem:4d}"
+    )
+
+    # Plot each intermediate adapted mesh
+    fig, axes = plt.subplots(figsize=(10, 2))
+    mesh_seq.plot(fig=fig, axes=axes, interior_kw=interior_kw)
+    axes.set_title(f"Mesh at iteration {iteration + 1}")
+    fig.savefig(f"point_discharge2d-aniso_go_mesh{iteration + 1}.jpg")
+    plt.close()
+
+    # Plot error indicator on intermediate meshes
+    plot_kwargs["norm"] = mcolors.LogNorm()
+    plot_kwargs["locator"] = ticker.LogLocator()
+    fig, axes, tcs = plot_indicator_snapshots(
+        indicators, time_partition, "c", **plot_kwargs
+    )
+    axes.set_title(f"Indicator at iteration {mesh_seq.fp_iteration + 1}")
+    fig.colorbar(tcs[0][0], orientation="horizontal", pad=0.2)
+    fig.savefig(f"point_discharge2d-aniso_go_indicator{mesh_seq.fp_iteration + 1}.jpg")
+    plt.close()
+
+    # If the target complexity has not been reached, skip to the next iteration
+    return complexity < 0.95 * target
+
+
+# To avoid confusion, we redefine the :class:`GoalOrientedMeshSeq` object before using
+# it. ::
+
+mesh_seq = GoalOrientedMeshSeq(
+    time_partition,
+    mesh,
+    get_function_spaces=get_function_spaces,
+    get_form=get_form,
+    get_bcs=get_bcs,
+    get_solver=get_solver,
+    get_qoi=get_qoi,
+    qoi_type="steady",
+    parameters=params,
+)
+solutions = mesh_seq.fixed_point_iteration(adaptor)
+qoi_aniso = mesh_seq.qoi_values
+dofs_aniso = mesh_seq.vertex_counts
+
+# .. code-block:: console
+#
+#     1, complexity:  400, dofs:  561, elements: 1000
+#     2, complexity:  600, dofs:  590, elements: 1121
+#     3, complexity:  800, dofs:  876, elements: 1700
+#     4, complexity: 1000, dofs: 1079, elements: 2101
+#    Terminated due to QoI convergence after 5 iterations
+#
+# ::
+
+fig, axes = plt.subplots(figsize=(10, 2))
+mesh_seq.plot(fig=fig, axes=axes, interior_kw=interior_kw)
+axes.set_title("Adapted mesh")
+fig.savefig("point_discharge2d-aniso_go_mesh.jpg")
+plt.close()
+
+plot_kwargs = {"levels": 50, "figsize": (10, 3), "cmap": "coolwarm"}
+fig, axes, tcs = plot_snapshots(
+    solutions,
+    time_partition,
+    "c",
+    "forward",
+    **plot_kwargs,
+)
+fig.colorbar(tcs[0][0], orientation="horizontal", pad=0.2)
+axes.set_title("Forward solution on adapted mesh")
+fig.savefig("point_discharge2d-forward_aniso_go_adapted.jpg")
+plt.close()
+
+# .. figure:: point_discharge2d-aniso_go_mesh.jpg
+#    :figwidth: 100%
+#    :align: center
+#
+# .. figure:: point_discharge2d-forward_aniso_go_adapted.jpg
+#    :figwidth: 80%
+#    :align: center
+#
+# This time, the elements are clearly anisotropic. This anisotropy is inherited from the
+# Hessian of the adjoint solution. There is still high resolution at the source and
+# receiver, as well as coarse resolution downstream.
+#
+# This demo can also be accessed as a `Python script <point_discharge2d-goal_oriented.py>`__.

--- a/demos/point_discharge2d-goal_oriented.py
+++ b/demos/point_discharge2d-goal_oriented.py
@@ -191,8 +191,11 @@ def adaptor(mesh_seq, solutions, indicators):
     fig.savefig(f"point_discharge2d-iso_go_indicator{mesh_seq.fp_iteration + 1}.jpg")
     plt.close()
 
-    # If the target complexity has not been reached, skip to the next iteration
-    return complexity < 0.95 * target
+    # Check whether the target complexity has been (approximately) reached. If not,
+    # return ``True`` to indicate that convergence checks should be skipped until the
+    # next fixed point iteration.
+    continue_unconditionally = complexity < 0.95 * target
+    return continue_unconditionally
 
 
 # With the adaptor function defined, we can call the fixed point iteration method. Note
@@ -306,8 +309,11 @@ def adaptor(mesh_seq, solutions, indicators):
     fig.savefig(f"point_discharge2d-aniso_go_indicator{mesh_seq.fp_iteration + 1}.jpg")
     plt.close()
 
-    # If the target complexity has not been reached, skip to the next iteration
-    return complexity < 0.95 * target
+    # Check whether the target complexity has been (approximately) reached. If not,
+    # return ``True`` to indicate that convergence checks should be skipped until the
+    # next fixed point iteration.
+    continue_unconditionally = complexity < 0.95 * target
+    return continue_unconditionally
 
 
 # To avoid confusion, we redefine the :class:`GoalOrientedMeshSeq` object before using

--- a/demos/point_discharge2d-goal_oriented.py
+++ b/demos/point_discharge2d-goal_oriented.py
@@ -40,7 +40,7 @@ def get_form(mesh_seq):
         h = CellSize(mesh_seq[index])
         S = source(mesh_seq[index])
 
-        # Stabilisation parameter
+        # SUPG stabilisation parameter
         unorm = sqrt(dot(u, u))
         tau = 0.5 * h / unorm
         tau = min_value(tau, unorm * h / (6 * D))

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -147,7 +147,7 @@ plt.close()
 # For this first example, we compute a metric by recovering the Hessian of the
 # approximate solution field, and scaling it according to a desired *metric complexity*
 # using :math:`L^p` normalisation. The normalised metric is used to adapt the mesh,
-# which we print the element count of and plot. ::
+# which we print the vertex count of and plot. ::
 
 
 def adaptor(mesh_seq, solutions):
@@ -169,7 +169,7 @@ def adaptor(mesh_seq, solutions):
     # Normalise the metric according to the target complexity and then adapt the mesh
     metric.normalise()
     mesh_seq[0] = adapt(mesh_seq[0], metric)
-    pyrint(f"Iteration {iteration + 1}: {mesh_seq.element_counts[-1][0]} elements")
+    pyrint(f"Iteration {iteration + 1}: {mesh_seq.vertex_counts[-1][0]} vertices")
 
     # Plot each intermediate adapted mesh
     fig, axes = plt.subplots(figsize=(10, 2))

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -44,7 +44,7 @@ def get_form(mesh_seq):
         h = CellSize(mesh_seq[index])
         S = source(mesh_seq[index])
 
-        # Stabilisation parameter
+        # SUPG stabilisation parameter
         unorm = sqrt(dot(u, u))
         tau = 0.5 * h / unorm
         tau = min_value(tau, unorm * h / (6 * D))

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -247,4 +247,7 @@ plt.close()
 # curvature in the solution field. Moreover, it is anisotropic, with the orientation of
 # anisotropic elements aligned with the contours of the solution field.
 #
+# In the `next demo <./point_discharge2d-goal_oriented.py.html>`__, we consider the same
+# problem again, but using *goal-oriented* mesh adaptation.
+#
 # This demo can also be accessed as a `Python script <point_discharge2d-hessian.py>`__.

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -191,8 +191,11 @@ def adaptor(mesh_seq, solutions):
     fig.savefig(f"point_discharge2d-hessian_mesh{iteration + 1}.jpg")
     plt.close()
 
-    # If the target complexity has not been reached, skip to the next iteration
-    return complexity < 0.95 * target
+    # Check whether the target complexity has been (approximately) reached. If not,
+    # return ``True`` to indicate that convergence checks should be skipped until the
+    # next fixed point iteration.
+    continue_unconditionally = complexity < 0.95 * target
+    return continue_unconditionally
 
 
 # With the adaptor function defined, we can call the fixed point iteration method, which

--- a/demos/point_discharge2d.py
+++ b/demos/point_discharge2d.py
@@ -109,7 +109,9 @@ def get_bcs(mesh_seq):
     return bcs
 
 
-# With these ingredients, we can now define the :meth:`get_solver` method. ::
+# With these ingredients, we can now define the :meth:`get_solver` method. Don't forget
+# to impose the correct names for the current and lagged solution fields, as well as
+# applying the corresponding `ad_block_tag` to the solve call. ::
 
 
 def get_solver(mesh_seq):

--- a/demos/point_discharge2d.py
+++ b/demos/point_discharge2d.py
@@ -76,7 +76,7 @@ def get_form(mesh_seq):
         h = CellSize(mesh_seq[index])
         S = source(mesh_seq[index])
 
-        # Stabilisation parameter
+        # SUPG stabilisation parameter
         unorm = sqrt(dot(u, u))
         tau = 0.5 * h / unorm
         tau = min_value(tau, unorm * h / (6 * D))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,3 +93,4 @@ earlier ones.
     :maxdepth: 1
 
     Hessian-based mesh adaptation for a 2D steady-state problem <demos/point_discharge2d-hessian.py>
+    Goal-oriented mesh adaptation for a 2D steady-state problem <demos/point_discharge2d-goal_oriented.py>

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -449,8 +449,10 @@ class AdjointMeshSeq(MeshSeq):
         """
         P = self.params
         self.converged = False
+        if not self.check_convergence:
+            return self.converged
         if len(self.qoi_values) < max(2, P.miniter):
-            return
+            return self.converged
         qoi_ = self.qoi_values[-2]
         qoi = self.qoi_values[-1]
         if abs(qoi - qoi_) < P.qoi_rtol * abs(qoi_):

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -8,7 +8,7 @@ from .interpolation import project
 from .mesh_seq import MeshSeq
 from .options import GoalOrientedParameters
 from .time_partition import TimePartition
-from .utility import AttrDict, norm, Function
+from .utility import AttrDict, norm, Function, pyrint
 from collections.abc import Callable
 from functools import wraps
 import numpy as np
@@ -453,6 +453,11 @@ class AdjointMeshSeq(MeshSeq):
             return
         qoi_ = self.qoi_values[-2]
         qoi = self.qoi_values[-1]
-        self.converged = True
-        if abs(qoi - qoi_) > P.qoi_rtol * abs(qoi_):
-            self.converged = False
+        if abs(qoi - qoi_) < P.qoi_rtol * abs(qoi_):
+            self.converged = True
+        if self.converged:
+            pyrint(
+                f"Terminated due to QoI convergence after {self.fp_iteration+1}"
+                " iterations."
+            )
+        return self.converged

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -97,7 +97,6 @@ class AdjointMeshSeq(MeshSeq):
         self.J = 0
         self.controls = None
         self.qoi_values = []
-        self.fp_iteration = 0
 
     @property
     @pyadjoint.no_annotations

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -306,6 +306,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             # Adapt meshes and log element counts
             adaptor(self, sols, indicators)
             self.element_counts.append(self.count_elements())
+            self.vertex_counts.append(self.count_vertices())
 
             # Check for element count convergence
             self.check_element_count_convergence()

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -261,7 +261,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             skipped for this iteration. Otherwise, it should return ``False``.
         :kwarg update_params: function for updating :attr:`~.GoalOrientedMeshSeq.params`
             at each iteration. Its arguments are the parameter class and the fixed point
-            iteration
+            iteration number
         :kwarg enrichment_kwargs: keyword arguments to pass to the global enrichment
             method
         :kwarg adj_kwargs: keyword arguments to pass to the adjoint solver

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -231,7 +231,6 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         self.converged = False
         if len(self.estimator_values) < max(2, P.miniter):
             return
-        self.converged = True
         ee_ = self.estimator_values[-2]
         ee = self.estimator_values[-1]
         if abs(ee - ee_) < P.estimator_rtol * abs(ee_):

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -65,6 +65,7 @@ class MeshSeq:
         if not isinstance(self.meshes, Iterable):
             self.meshes = [Mesh(initial_meshes) for subinterval in self.subintervals]
         self.element_counts = [self.count_elements()]
+        self.vertex_counts = [self.count_vertices()]
         dim = np.array([mesh.topological_dimension() for mesh in self.meshes])
         if dim.min() != dim.max():
             raise ValueError("Meshes must all have the same topological dimension.")
@@ -122,6 +123,9 @@ class MeshSeq:
 
     def count_elements(self) -> list:
         return [mesh.num_cells() for mesh in self]  # TODO: make parallel safe
+
+    def count_vertices(self) -> list:
+        return [mesh.num_vertices() for mesh in self]  # TODO: make parallel safe
 
     def plot(
         self, **kwargs

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -90,6 +90,7 @@ class MeshSeq:
         self.params = kwargs.get("parameters")
         self.steady = time_partition.steady
         self.check_convergence = True
+        self.fp_iteration = 0
         if self.params is None:
             self.params = AdaptParameters()
         self.warn = kwargs.get("warnings", True)

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -637,6 +637,7 @@ class MeshSeq:
             # Adapt meshes and log element counts
             adaptor(self, sols)
             self.element_counts.append(self.count_elements())
+            self.vertex_counts.append(self.count_vertices())
 
             # Check for element count convergence
             self.check_element_count_convergence()

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -337,7 +337,14 @@ def anisotropic_dwr_metric(
         metric.project(P0_metric)
     else:
         raise ValueError(f"Interpolant {interpolant} not recognised")
-    metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=False)
+
+    # Rescale to enforce that the target complexity is met
+    mp = {
+        "dm_plex_metric_target_complexity": target_complexity,
+        "dm_plex_metric_p": np.inf,
+    }
+    metric.set_parameters(mp)
+    metric.normalise()
     return metric
 
 

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -136,7 +136,10 @@ def assemble_eigendecomposition(
     elif (fe_vec.family(), fe_vec.degree()) == ("Discontinuous Lagrange", 0):
         M = P0Metric(V_ten)
     else:
-        raise ValueError  # TODO: msg
+        raise ValueError(
+            "Can only work with RiemannianMetrics defined in P1 space or P0 space, not"
+            f"{fe_vec}."
+        )
     op2.par_loop(
         get_metric_kernel("set_eigendecomposition", dim),
         V_ten.node_set,

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -342,6 +342,8 @@ def anisotropic_dwr_metric(
         raise ValueError(f"Interpolant {interpolant} not recognised")
 
     # Rescale to enforce that the target complexity is met
+    #   Note that we use the L-infinity norm so that the metric is just scaled to the
+    #   target metric complexity, as opposed to being redistributed spatially.
     mp = {
         "dm_plex_metric_target_complexity": target_complexity,
         "dm_plex_metric_p": np.inf,

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -177,15 +177,13 @@ def isotropic_metric(
                     f" space, not {family} of degree {degree}"
                 )
             error_indicator = clement_interpolant(error_indicator)
-    if interpolant in ("Clement", "interpolate"):
-        metric.interpolate(abs(error_indicator) * ufl.Identity(dim))
-    elif interpolant in ("L2", "project"):
+    if interpolant in ("L2", "project"):
         error_indicator = firedrake.project(
             error_indicator, FunctionSpace(mesh, "CG", 1)
         )
-        metric.interpolate(abs(error_indicator) * ufl.Identity(dim))
-    else:
-        raise ValueError(f"Interpolant {interpolant} not recognised")
+    elif interpolant not in ("Clement", "interpolate"):
+        raise ValueError(f"Interpolant '{interpolant}' not recognised.")
+    metric.interpolate(abs(error_indicator) * ufl.Identity(dim))
     return metric
 
 

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -178,12 +178,12 @@ def isotropic_metric(
                 )
             error_indicator = clement_interpolant(error_indicator)
     if interpolant in ("Clement", "interpolate"):
-        metric.interpolate(abs(error_indicator) * ufl.Identity(dim), target_space)
+        metric.interpolate(abs(error_indicator) * ufl.Identity(dim))
     elif interpolant in ("L2", "project"):
         error_indicator = firedrake.project(
             error_indicator, FunctionSpace(mesh, "CG", 1)
         )
-        metric.interpolate(abs(error_indicator) * ufl.Identity(dim), target_space)
+        metric.interpolate(abs(error_indicator) * ufl.Identity(dim))
     else:
         raise ValueError(f"Interpolant {interpolant} not recognised")
     return metric

--- a/pyroteus/metric.py
+++ b/pyroteus/metric.py
@@ -94,7 +94,7 @@ def compute_eigendecomposition(
 @PETSc.Log.EventDecorator()
 def assemble_eigendecomposition(
     evectors: Function, evalues: Function
-) -> Union[RiemannianMetric, P0Metric]:
+) -> RiemannianMetric:
     """
     Assemble a matrix from its eigenvectors and
     eigenvalues.

--- a/test/test_mesh_seq.py
+++ b/test/test_mesh_seq.py
@@ -126,3 +126,14 @@ class TestStringFormatting(TestGeneric):
             "Mesh(VectorElement(FiniteElement('Lagrange', triangle, 1), dim=2), .*)])"
         )
         self.assertTrue(re.match(repr(mesh_seq), expected))
+
+
+class TestMeshSeq(TestStringFormatting):
+    """
+    Unit tests for basic :class:`MeshSeq` functionality.
+    """
+
+    def test_counting(self):
+        mesh_seq = MeshSeq(self.time_interval, [UnitSquareMesh(3, 3)])
+        self.assertEqual(mesh_seq.count_elements(), [18])
+        self.assertEqual(mesh_seq.count_vertices(), [16])

--- a/test_adjoint/test_utils.py
+++ b/test_adjoint/test_utils.py
@@ -104,24 +104,28 @@ class TestAdjointUtils(unittest.TestCase):
 
     def test_qoi_convergence_values_lt_2(self):
         mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = [1.0]
         mesh_seq.check_qoi_convergence()
         self.assertFalse(mesh_seq.converged)
 
     def test_qoi_convergence_values_lt_miniter(self):
         mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter - 1)
         mesh_seq.check_qoi_convergence()
         self.assertFalse(mesh_seq.converged)
 
     def test_qoi_convergence_values_constant(self):
         mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter)
         mesh_seq.check_qoi_convergence()
         self.assertTrue(mesh_seq.converged)
 
     def test_qoi_convergence_values_not_converged(self):
         mesh_seq = self.mesh_seq("end_time")
+        mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter)
         mesh_seq.qoi_values[-1] = 100.0
         mesh_seq.check_qoi_convergence()


### PR DESCRIPTION
Builds on #133 to consider isotropic and anisotropic goal-oriented metrics. Also includes some tweaks to ``MeshSeq`` and its subclesses, as well as fixes to ``anisotropic_dwr_metric``.