### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Install Pyroteus
-        run: |
-          . /home/firedrake/firedrake-parmmg/bin/activate
-          python -m pip install -r requirements.txt
-          python -m pip install -e .
       - name: Test Pyroteus
         run: |
           . /home/firedrake/firedrake-parmmg/bin/activate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: 3.8
       - name: Test Pyroteus
         run: |
-          . /home/firedrake/firedrake-parmmg/bin/activate
+          . /home/firedrake/firedrake/bin/activate
           python $(which firedrake-clean)
           python -m coverage erase
           python -m coverage run -a --source=pyroteus -m pytest -v --durations=20 test
@@ -38,5 +38,5 @@ jobs:
       - name: Lint
         if: ${{ always() }}
         run: |
-          . /home/firedrake/firedrake-parmmg/bin/activate
+          . /home/firedrake/firedrake/bin/activate
           make lint

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ lint:
 
 test: lint
 	@echo "Running test suite..."
-	@cd test && make && ..
-	@cd test_adjoint && make && ..
+	@cd test && make
+	@cd test_adjoint && make
 	@echo "PASS"
 
 coverage:

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -1,0 +1,34 @@
+FROM firedrakeproject/firedrake:latest
+
+MAINTAINER Joe Wallwork <joe.wallwork@outlook.com>
+
+USER firedrake
+WORKDIR /home/firedrake
+
+# Reconfigure PETSc with Mmg and ParMmg
+RUN bash -c "cd petsc; \
+	git fetch; \
+	git checkout jwallwork23/parmmg-rebased; \
+	cp default/lib/petsc/conf/reconfigure-default.py .; \
+	sed -i '30i \ \ \ \ '\''--download-parmmg'\'',' reconfigure-default.py; \
+	sed -i '30i \ \ \ \ '\''--download-mmg'\'',' reconfigure-default.py; \
+	./reconfigure-default.py"
+
+# Rebuild PETSc
+RUN bash -c "cd petsc; \
+	make all"
+
+# Rebuild Firedrake
+RUN bash -c "source firedrake/bin/activate; \
+	cd firedrake/src/firedrake; \
+	git fetch; \
+	git switch jwallwork23/parmmg-metric-based; \
+	firedrake-update"
+
+# Install Pyroteus
+RUN bash -c "source firedrake/bin/activate; \
+	cd firedrake/src; \
+	git clone https://github.com/pyroteus/pyroteus.git; \
+	cd pyroteus; \
+	python3 -m pip install -r requirements.txt; \
+	python3 -m pip install -e ."

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -13,6 +13,8 @@ RUN bash -c "cd petsc; \
 	sed -i '30i \ \ \ \ '\''--download-parmmg'\'',' reconfigure-default.py; \
 	sed -i '30i \ \ \ \ '\''--download-mmg'\'',' reconfigure-default.py; \
 	sed -i '30i \ \ \ \ '\''--download-eigen'\'',' reconfigure-default.py; \
+	sed -i '30i \ \ \ \ '\''--download-triangle'\'',' reconfigure-default.py; \
+	sed -i '30i \ \ \ \ '\''--download-tetgen'\'',' reconfigure-default.py; \
 	./reconfigure-default.py"
 
 # Rebuild PETSc

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -12,6 +12,7 @@ RUN bash -c "cd petsc; \
 	cp default/lib/petsc/conf/reconfigure-default.py .; \
 	sed -i '30i \ \ \ \ '\''--download-parmmg'\'',' reconfigure-default.py; \
 	sed -i '30i \ \ \ \ '\''--download-mmg'\'',' reconfigure-default.py; \
+	sed -i '30i \ \ \ \ '\''--download-eigen'\'',' reconfigure-default.py; \
 	./reconfigure-default.py"
 
 # Rebuild PETSc

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,10 @@
+all: build
+
+build:
+	docker build -f Dockerfile.firedrake -t jwallwork/firedrake-parmmg --no-cache .
+
+pull:
+	docker pull jwallwork/firedrake-parmmg
+
+run:
+	docker run --rm -it -v ${HOME}:${HOME} jwallwork/firedrake-parmmg


### PR DESCRIPTION
Okay I finally managed to get this working!

The idea is to take the existing "default" Firedrake docker image and then:
1. Reconfigure PETSc, installing Pyroteus requirements (Mmg, ParMmg and Eigen), plus Triangle and Tetgen for PETSc testing.
2. Rebuild PETSc.
3. Update Firedrake on top of it. (This was the only way I could get mpich/mpi4py to be set up properly.)
4. Install Pyroteus.

Admittedly, using `sed` is pretty hacky. But it avoids copying out the long list of packages and settings again.

Closes #139.