### PR TITLE
Convergence status per subinterval

### DIFF
--- a/demos/point_discharge2d-goal_oriented.py
+++ b/demos/point_discharge2d-goal_oriented.py
@@ -197,7 +197,7 @@ def adaptor(mesh_seq, solutions, indicators):
     # return ``True`` to indicate that convergence checks should be skipped until the
     # next fixed point iteration.
     continue_unconditionally = complexity < 0.95 * target
-    return continue_unconditionally
+    return [continue_unconditionally]
 
 
 # With the adaptor function defined, we can call the fixed point iteration method. Note
@@ -319,7 +319,7 @@ def adaptor(mesh_seq, solutions, indicators):
     # return ``True`` to indicate that convergence checks should be skipped until the
     # next fixed point iteration.
     continue_unconditionally = complexity < 0.95 * target
-    return continue_unconditionally
+    return [continue_unconditionally]
 
 
 # To avoid confusion, we redefine the :class:`GoalOrientedMeshSeq` object before using

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -195,7 +195,7 @@ def adaptor(mesh_seq, solutions):
     # return ``True`` to indicate that convergence checks should be skipped until the
     # next fixed point iteration.
     continue_unconditionally = complexity < 0.95 * target
-    return continue_unconditionally
+    return [continue_unconditionally]
 
 
 # With the adaptor function defined, we can call the fixed point iteration method, which

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -405,7 +405,7 @@ class AdjointMeshSeq(MeshSeq):
                 for field, control in zip(self.fields, self.controls)
             }
             for field, seed in seeds.items():
-                if np.isclose(norm(seed), 0.0):
+                if not self.steady and np.isclose(norm(seed), 0.0):
                     self.warning(
                         f"Adjoint action for field '{field}' on {self.th(i)}"
                         " subinterval is zero."

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -226,7 +226,7 @@ class AdjointMeshSeq(MeshSeq):
             run_final_subinterval=test_checkpoint_qoi,
         )
         J_chk = float(self.J)
-        if self.warn and test_checkpoint_qoi and np.isclose(J_chk, 0.0):
+        if test_checkpoint_qoi and np.isclose(J_chk, 0.0):
             self.warning("Zero QoI. Is it implemented as intended?")
 
         # Reset the QoI to zero
@@ -292,7 +292,7 @@ class AdjointMeshSeq(MeshSeq):
                 if self.qoi_type in ["end_time", "steady"]:
                     qoi = self.get_qoi(checkpoint, i)
                     self.J = qoi(**qoi_kwargs)
-                    if self.warn and np.isclose(float(self.J), 0.0):
+                    if np.isclose(float(self.J), 0.0):
                         self.warning("Zero QoI. Is it implemented as intended?")
             else:
                 with pyadjoint.stop_annotating():
@@ -386,17 +386,16 @@ class AdjointMeshSeq(MeshSeq):
                             )
 
                 # Check non-zero adjoint solution/value
-                if self.warn:
-                    if np.isclose(norm(solutions[field].adjoint[i][0]), 0.0):
-                        self.warning(
-                            f"Adjoint solution for field '{field}' on {self.th(i)}"
-                            " subinterval is zero."
-                        )
-                    if get_adj_values and np.isclose(norm(sols.adj_value[i][0]), 0.0):
-                        self.warning(
-                            f"Adjoint action for field '{field}' on {self.th(i)}"
-                            " subinterval is zero."
-                        )
+                if np.isclose(norm(solutions[field].adjoint[i][0]), 0.0):
+                    self.warning(
+                        f"Adjoint solution for field '{field}' on {self.th(i)}"
+                        " subinterval is zero."
+                    )
+                if get_adj_values and np.isclose(norm(sols.adj_value[i][0]), 0.0):
+                    self.warning(
+                        f"Adjoint action for field '{field}' on {self.th(i)}"
+                        " subinterval is zero."
+                    )
 
             # Get adjoint action on each subinterval
             seeds = {
@@ -405,13 +404,12 @@ class AdjointMeshSeq(MeshSeq):
                 )
                 for field, control in zip(self.fields, self.controls)
             }
-            if self.warn:
-                for field, seed in seeds.items():
-                    if np.isclose(norm(seed), 0.0):
-                        self.warning(
-                            f"Adjoint action for field '{field}' on {self.th(i)}"
-                            " subinterval is zero."
-                        )
+            for field, seed in seeds.items():
+                if np.isclose(norm(seed), 0.0):
+                    self.warning(
+                        f"Adjoint action for field '{field}' on {self.th(i)}"
+                        " subinterval is zero."
+                    )
 
             # Clear the tape to reduce the memory footprint
             tape.clear_tape()

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -439,26 +439,20 @@ class AdjointMeshSeq(MeshSeq):
 
     def check_qoi_convergence(self):
         """
-        Check for convergence of the fixed point iteration
-        due to the relative difference in QoI value being
-        smaller than the specified tolerance.
+        Check for convergence of the fixed point iteration due to the relative
+        difference in QoI value being smaller than the specified tolerance.
 
-        The :attr:`AdjointMeshSeq.converged` attribute
-        is set to ``True`` if convergence is detected.
+        The :attr:`AdjointMeshSeq.converged` attribute is set to ``True`` across all
+        entries if convergence is detected.
         """
-        P = self.params
-        self.converged = False
-        if not self.check_convergence:
+        if not self.check_convergence.any():
             return self.converged
-        if len(self.qoi_values) < max(2, P.miniter):
-            return self.converged
-        qoi_ = self.qoi_values[-2]
-        qoi = self.qoi_values[-1]
-        if abs(qoi - qoi_) < P.qoi_rtol * abs(qoi_):
-            self.converged = True
-        if self.converged:
-            pyrint(
-                f"Terminated due to QoI convergence after {self.fp_iteration+1}"
-                " iterations."
-            )
+        if len(self.qoi_values) >= max(2, self.params.miniter + 1):
+            qoi_, qoi = self.qoi_values[-2:]
+            if abs(qoi - qoi_) < self.params.qoi_rtol * abs(qoi_):
+                self.converged[:] = True
+                pyrint(
+                    f"Terminated due to QoI convergence after {self.fp_iteration+1}"
+                    " iterations."
+                )
         return self.converged

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -435,6 +435,10 @@ class AdjointMeshSeq(MeshSeq):
             c = "th"
         return f"{num}{c}"
 
+    def _subintervals_not_checked(self):
+        num_not_checked = len(self.check_convergence[not self.check_convergence])
+        return self.check_convergence.argsort()[num_not_checked]
+
     def check_qoi_convergence(self):
         """
         Check for convergence of the fixed point iteration due to the relative
@@ -444,6 +448,10 @@ class AdjointMeshSeq(MeshSeq):
         entries if convergence is detected.
         """
         if not self.check_convergence.any():
+            self.info(
+                "Skipping QoI convergence check because check_convergence contains"
+                f" False values for indices {self._subintervals_not_checked}."
+            )
             return self.converged
         if len(self.qoi_values) >= max(2, self.params.miniter + 1):
             qoi_, qoi = self.qoi_values[-2:]

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -452,7 +452,7 @@ class AdjointMeshSeq(MeshSeq):
             if abs(qoi - qoi_) < self.params.qoi_rtol * abs(qoi_):
                 self.converged[:] = True
                 pyrint(
-                    f"Terminated due to QoI convergence after {self.fp_iteration+1}"
-                    " iterations."
+                    f"QoI converged after {self.fp_iteration+1} iterations"
+                    f" under relative tolerance {self.params.qoi_rtol}."
                 )
         return self.converged

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -226,6 +226,10 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         all entries if convergence is detected.
         """
         if not self.check_convergence.any():
+            self.info(
+                "Skipping estimator convergence check because check_convergence"
+                f" contains False values for indices {self._subintervals_not_checked}."
+            )
             return self.converged
         if len(self.estimator_values) >= max(2, self.params.miniter + 1):
             ee_, ee = self.estimator_values[-2:]

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -232,8 +232,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             if abs(ee - ee_) < self.params.estimator_rtol * abs(ee_):
                 self.converged[:] = True
                 pyrint(
-                    "Terminated due to error estimator convergence after"
-                    f" {self.fp_iteration+1} iterations."
+                    f"Error estimator converged after {self.fp_iteration+1} iterations"
+                    f" under relative tolerance {self.params.estimator_rtol}."
                 )
         return self.converged
 

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -298,7 +298,9 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
 
             # Adapt meshes and log element counts
             continue_unconditionally = adaptor(self, sols, indicators)
-            self.check_convergence[:] = np.logical_not(continue_unconditionally)
+            self.check_convergence[:] = np.logical_not(
+                np.logical_or(continue_unconditionally, self.converged)
+            )
             self.element_counts.append(self.count_elements())
             self.vertex_counts.append(self.count_vertices())
 

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -190,13 +190,10 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                     f" {type(forms)}."
                 )
 
-            # Construct the error indicator
-            for j in range(len(sols[self.fields[0]]["forward"][i])):
-                P0_e = FunctionSpace(mesh_seq_e[i], "DG", 0)
-                indi_e = Function(P0_e)
-
-                # Loop over each strongly coupled field
-                for f in self.fields:
+            # Loop over each strongly coupled field
+            for f in self.fields:
+                # Loop over each timestep
+                for j in range(len(sols[f]["forward"][i])):
                     # Update fields
                     transfer(sols[f][FWD][i][j], u[f])
                     transfer(sols[f][FWD_OLD][i][j], u_[f])

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -55,7 +55,6 @@ class MeshSeq:
             :class:`~.MeshSeq`, which returns a function that
             determines any Dirichlet boundary conditions
         :kwarg parameters: :class:`~.AdaptParameters` instance
-        :kwarg warnings: print warnings?
         """
         self.time_partition = time_partition
         self.fields = time_partition.fields
@@ -94,7 +93,6 @@ class MeshSeq:
         self.fp_iteration = 0
         if self.params is None:
             self.params = AdaptParameters()
-        self.warn = kwargs.get("warnings", True)
         self.sections = [{} for mesh in self]
 
     def __str__(self) -> str:

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -640,7 +640,9 @@ class MeshSeq:
 
             # Adapt meshes, logging element and vertex counts
             continue_unconditionally = adaptor(self, sols)
-            self.check_convergence[:] = np.logical_not(continue_unconditionally)
+            self.check_convergence[:] = np.logical_not(
+                np.logical_or(continue_unconditionally, self.converged)
+            )
             self.element_counts.append(self.count_elements())
             self.vertex_counts.append(self.count_vertices())
 

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -599,6 +599,10 @@ class MeshSeq:
         if len(self.element_counts) >= max(2, self.params.miniter + 1):
             for i, (ne_, ne) in enumerate(zip(*self.element_counts[-2:])):
                 if not self.check_convergence[i]:
+                    self.info(
+                        f"Skipping element count convergence check on subinterval {i})"
+                        f" because check_convergence[{i}] == False."
+                    )
                     continue
                 if abs(ne - ne_) <= self.params.element_rtol * ne_:
                     self.converged[i] = True

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -602,8 +602,9 @@ class MeshSeq:
                 if abs(ne - ne_) <= self.params.element_rtol * ne_:
                     self.converged[i] = True
                     pyrint(
-                        f"Dropping out subinterval {i} due to element count convergence"
-                        f" after {self.fp_iteration+1} iterations."
+                        f"Element count converged on subinterval {i} after"
+                        f" {self.fp_iteration+1} iterations under relative tolerance"
+                        f" {self.params.element_rtol}."
                     )
         return self.converged
 

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -606,11 +606,18 @@ class MeshSeq:
                     continue
                 if abs(ne - ne_) <= self.params.element_rtol * ne_:
                     self.converged[i] = True
-                    pyrint(
-                        f"Element count converged on subinterval {i} after"
-                        f" {self.fp_iteration+1} iterations under relative tolerance"
-                        f" {self.params.element_rtol}."
-                    )
+                    if len(self) == 1:
+                        pyrint(
+                            f"Element count converged after {self.fp_iteration+1}"
+                            " iterations under relative tolerance"
+                            f" {self.params.element_rtol}."
+                        )
+                    else:
+                        pyrint(
+                            f"Element count converged on subinterval {i} after"
+                            f" {self.fp_iteration+1} iterations under relative tolerance"
+                            f" {self.params.element_rtol}."
+                        )
         return self.converged
 
     @PETSc.Log.EventDecorator()

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -7,7 +7,7 @@ from firedrake.adjoint.solving import get_solve_blocks
 from firedrake.adjoint.blocks import GenericSolveBlock
 from pyadjoint import get_working_tape, Block
 from .interpolation import project
-from .log import pyrint, debug, warning, logger, DEBUG
+from .log import pyrint, debug, warning, info, logger, DEBUG
 from .options import AdaptParameters
 from .quality import QualityMeasure
 from .time_partition import TimePartition
@@ -112,6 +112,9 @@ class MeshSeq:
 
     def warning(self, msg: str):
         warning(f"{self.__class__.__name__}: {msg}")
+
+    def info(self, msg: str):
+        info(f"{self.__class__.__name__}: {msg}")
 
     def __len__(self) -> int:
         return len(self.meshes)

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -1,0 +1,66 @@
+from firedrake import *
+from pyroteus_adjoint import *
+import unittest
+
+
+def get_function_spaces(mesh):
+    return {}
+
+
+def get_form(mesh_seq):
+    def form(index, sols):
+        return {}
+
+    return form
+
+
+def get_bcs(mesh_seq):
+    def bcs(index):
+        return []
+
+    return bcs
+
+
+def get_solver(mesh_seq):
+    def solver(index, ic):
+        return {}
+
+    return solver
+
+
+class TestMeshSeq(unittest.TestCase):
+    """
+    Unit tests for :meth:`MeshSeq.fixed_point_iteration`.
+    """
+
+    def setUp(self):
+        self.parameters = AdaptParameters()
+        time_partition = TimeInstant([])
+        self.mesh_seq = MeshSeq(
+            time_partition,
+            UnitTriangleMesh(),
+            get_function_spaces=get_function_spaces,
+            get_form=get_form,
+            get_bcs=get_bcs,
+            get_solver=get_solver,
+            parameters=self.parameters,
+        )
+
+    def test_convergence_noop(self):
+        def adaptor(mesh_seq, sols):
+            pass
+
+        miniter = self.parameters.miniter
+        self.mesh_seq.fixed_point_iteration(adaptor)
+        self.assertEqual(len(self.mesh_seq.element_counts), miniter + 1)
+
+    def test_noconvergence(self):
+        mesh1 = UnitSquareMesh(1, 1)
+        mesh2 = UnitTriangleMesh()
+
+        def adaptor(mesh_seq, sols):
+            mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
+
+        maxiter = self.parameters.maxiter
+        self.mesh_seq.fixed_point_iteration(adaptor)
+        self.assertEqual(len(self.mesh_seq.element_counts), maxiter + 1)

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -28,6 +28,16 @@ def get_solver(mesh_seq):
     return solver
 
 
+def get_qoi(mesh_seq, solutions, index):
+    def qoi():
+        if mesh_seq.fp_iteration % 2 == 0:
+            return Constant(1, domain=mesh_seq[index]) * dx
+        else:
+            return Constant(2, domain=mesh_seq[index]) * dx
+
+    return qoi
+
+
 class TestMeshSeq(unittest.TestCase):
     """
     Unit tests for :meth:`MeshSeq.fixed_point_iteration`.
@@ -89,6 +99,64 @@ class TestMeshSeq(unittest.TestCase):
         self.assertEqual(mesh_seq.element_counts, expected)
 
 
-# TODO: GoalOrientedMeshSeq version
-#  - tweak the qoi function and the indicator_fn
-#  - Test the new 'drop out' functionality
+class TestGoalOrientedMeshSeq(unittest.TestCase):
+    """
+    Unit tests for :meth:`GoalOrientedMeshSeq.fixed_point_iteration`.
+    """
+
+    def setUp(self):
+        self.parameters = GoalOrientedParameters(
+            {
+                "miniter": 3,
+                "maxiter": 5,
+            }
+        )
+
+    def mesh_seq(self, time_partition, mesh, qoi_type="steady"):
+        return GoalOrientedMeshSeq(
+            time_partition,
+            mesh,
+            get_function_spaces=get_function_spaces,
+            get_form=get_form,
+            get_bcs=get_bcs,
+            get_solver=get_solver,
+            get_qoi=get_qoi,
+            parameters=self.parameters,
+            qoi_type=qoi_type,
+        )
+
+    def test_convergence_noop(self):
+        def adaptor(mesh_seq, sols, indicators):
+            return [False]
+
+        miniter = self.parameters.miniter
+        mesh_seq = self.mesh_seq(TimeInstant([]), UnitTriangleMesh())
+        mesh_seq.fixed_point_iteration(adaptor)
+        self.assertEqual(len(mesh_seq.element_counts), miniter + 1)
+
+    def test_noconvergence(self):
+        mesh1 = UnitSquareMesh(1, 1)
+        mesh2 = UnitTriangleMesh()
+
+        def adaptor(mesh_seq, sols, indicators):
+            mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
+            return [False]
+
+        maxiter = self.parameters.maxiter
+        mesh_seq = self.mesh_seq(TimeInstant([]), mesh2)
+        mesh_seq.fixed_point_iteration(adaptor)
+        self.assertEqual(len(mesh_seq.element_counts), maxiter + 1)
+
+    def test_dropout(self):
+        mesh1 = UnitSquareMesh(1, 1)
+        mesh2 = UnitTriangleMesh()
+        time_partition = TimePartition(1.0, 2, [0.5, 0.5], [])
+        mesh_seq = self.mesh_seq(time_partition, mesh2, qoi_type="end_time")
+
+        def adaptor(mesh_seq, sols, indicators):
+            mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
+            return [False]
+
+        mesh_seq.fixed_point_iteration(adaptor)
+        expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
+        self.assertEqual(mesh_seq.element_counts, expected)

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -64,3 +64,8 @@ class TestMeshSeq(unittest.TestCase):
         maxiter = self.parameters.maxiter
         self.mesh_seq.fixed_point_iteration(adaptor)
         self.assertEqual(len(self.mesh_seq.element_counts), maxiter + 1)
+
+
+# TODO: GoalOrientedMeshSeq version
+#  - tweak the qoi function and the indicator_fn
+#  - Test the new 'drop out' functionality

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -70,6 +70,8 @@ class TestMeshSeq(unittest.TestCase):
         mesh_seq = self.mesh_seq(TimeInstant([]), UnitTriangleMesh())
         mesh_seq.fixed_point_iteration(adaptor)
         self.assertEqual(len(mesh_seq.element_counts), miniter + 1)
+        self.assertTrue(np.allclose(mesh_seq.converged, True))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, True))
 
     def test_noconvergence(self):
         mesh1 = UnitSquareMesh(1, 1)
@@ -83,6 +85,8 @@ class TestMeshSeq(unittest.TestCase):
         mesh_seq = self.mesh_seq(TimeInstant([]), mesh2)
         mesh_seq.fixed_point_iteration(adaptor)
         self.assertEqual(len(mesh_seq.element_counts), maxiter + 1)
+        self.assertTrue(np.allclose(mesh_seq.converged, False))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, True))
 
     def test_dropout(self):
         mesh1 = UnitSquareMesh(1, 1)
@@ -97,6 +101,8 @@ class TestMeshSeq(unittest.TestCase):
         mesh_seq.fixed_point_iteration(adaptor)
         expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
         self.assertEqual(mesh_seq.element_counts, expected)
+        self.assertTrue(np.allclose(mesh_seq.converged, [False, True]))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, [True, False]))
 
 
 class TestGoalOrientedMeshSeq(unittest.TestCase):
@@ -133,6 +139,8 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
         mesh_seq = self.mesh_seq(TimeInstant([]), UnitTriangleMesh())
         mesh_seq.fixed_point_iteration(adaptor)
         self.assertEqual(len(mesh_seq.element_counts), miniter + 1)
+        self.assertTrue(np.allclose(mesh_seq.converged, True))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, True))
 
     def test_noconvergence(self):
         mesh1 = UnitSquareMesh(1, 1)
@@ -146,6 +154,8 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
         mesh_seq = self.mesh_seq(TimeInstant([]), mesh2)
         mesh_seq.fixed_point_iteration(adaptor)
         self.assertEqual(len(mesh_seq.element_counts), maxiter + 1)
+        self.assertTrue(np.allclose(mesh_seq.converged, False))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, True))
 
     def test_dropout(self):
         mesh1 = UnitSquareMesh(1, 1)
@@ -160,3 +170,5 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
         mesh_seq.fixed_point_iteration(adaptor)
         expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
         self.assertEqual(mesh_seq.element_counts, expected)
+        self.assertTrue(np.allclose(mesh_seq.converged, [False, True]))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, [True, False]))

--- a/test_adjoint/test_utils.py
+++ b/test_adjoint/test_utils.py
@@ -104,29 +104,30 @@ class TestAdjointUtils(unittest.TestCase):
 
     def test_qoi_convergence_values_lt_2(self):
         mesh_seq = self.mesh_seq("end_time")
-        mesh_seq.fp_iteration = mesh_seq.params.miniter
+        mesh_seq.fp_iteration = mesh_seq.params.miniter + 1
         mesh_seq.qoi_values = [1.0]
         mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged)
+        self.assertFalse(mesh_seq.converged[0])
 
     def test_qoi_convergence_values_lt_miniter(self):
         mesh_seq = self.mesh_seq("end_time")
         mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter - 1)
         mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged)
+        self.assertFalse(mesh_seq.converged[0])
 
     def test_qoi_convergence_values_constant(self):
         mesh_seq = self.mesh_seq("end_time")
         mesh_seq.fp_iteration = mesh_seq.params.miniter
-        mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter)
+        mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter + 1)
         mesh_seq.check_qoi_convergence()
-        self.assertTrue(mesh_seq.converged)
+        print(mesh_seq.converged)
+        self.assertTrue(mesh_seq.converged[0])
 
     def test_qoi_convergence_values_not_converged(self):
         mesh_seq = self.mesh_seq("end_time")
         mesh_seq.fp_iteration = mesh_seq.params.miniter
-        mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter)
+        mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter + 1)
         mesh_seq.qoi_values[-1] = 100.0
         mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged)
+        self.assertFalse(mesh_seq.converged[0])

--- a/test_adjoint/test_utils.py
+++ b/test_adjoint/test_utils.py
@@ -121,7 +121,6 @@ class TestAdjointUtils(unittest.TestCase):
         mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter + 1)
         mesh_seq.check_qoi_convergence()
-        print(mesh_seq.converged)
         self.assertTrue(mesh_seq.converged[0])
 
     def test_qoi_convergence_values_not_converged(self):


### PR DESCRIPTION
The current behaviour of the fixed point iterations is that they will terminate when one of the following criteria are met:
1. The QoI (computed over all subintervals) converges w.r.t. a relative tolerance.
2. The error estimator (computed over all subintervals) converges w.r.t. a relative tolerance.
3. The number of mesh elements converges w.r.t. a relative tolerance *on each subinterval*.

@acse-ej321 had the idea to "drop out" subintervals that have already converged due to element count, meaning that their corresponding meshes are no longer adapted. This could reduce cost significantly in the case where we have many subintervals. However, since the user is given a lot of freedom via the `adaptor` function, the change in adaptation behaviour will presumably need to be made by them. Instead, this PR changes the convergence status behaviour so that it is a Boolean array, rather than a single bool.

Closes #144.