### PR TITLE
Refactor time partition

### DIFF
--- a/demos/burgers.py
+++ b/demos/burgers.py
@@ -151,7 +151,7 @@ time_partition = TimePartition(
     num_subintervals,
     dt,
     fields,
-    timesteps_per_export=2,
+    num_timesteps_per_export=2,
 )
 
 # Finally, we are able to construct a :class:`MeshSeq` and

--- a/demos/burgers1.py
+++ b/demos/burgers1.py
@@ -112,7 +112,7 @@ dt = 1 / n
 # single mesh, so the partition is trivial and we can use the
 # :class:`TimeInterval` constructor. ::
 
-time_partition = TimeInterval(end_time, dt, fields, timesteps_per_export=2)
+time_partition = TimeInterval(end_time, dt, fields, num_timesteps_per_export=2)
 
 # Finally, we are able to construct an :class:`AdjointMeshSeq` and
 # thereby call its :meth:`solve_adjoint` method. This computes the QoI

--- a/demos/burgers2.py
+++ b/demos/burgers2.py
@@ -12,6 +12,9 @@
 from firedrake import *
 from pyroteus_adjoint import *
 
+
+set_log_level(DEBUG)
+
 # Redefine the ``fields`` variable from the previous demo, as well as all the getter
 # functions. ::
 
@@ -96,7 +99,7 @@ dt = 1 / n
 
 num_subintervals = len(meshes)
 time_partition = TimePartition(
-    end_time, num_subintervals, dt, fields, timesteps_per_export=2, debug=True
+    end_time, num_subintervals, dt, fields, num_timesteps_per_export=2,
 )
 mesh_seq = AdjointMeshSeq(
     time_partition,

--- a/demos/burgers_ee.py
+++ b/demos/burgers_ee.py
@@ -27,6 +27,8 @@
 from firedrake import *
 from pyroteus_adjoint import *
 
+set_log_level(DEBUG)
+
 # Redefine the ``fields`` variable and the getter functions as in the first
 # adjoint Burgers demo. ::
 
@@ -106,7 +108,7 @@ end_time = 0.5
 dt = 1 / n
 num_subintervals = len(meshes)
 time_partition = TimePartition(
-    end_time, num_subintervals, dt, fields, timesteps_per_export=2, debug=True
+    end_time, num_subintervals, dt, fields, num_timesteps_per_export=2,
 )
 
 # A key difference between this demo and the previous ones is that we need to

--- a/demos/burgers_oo.py
+++ b/demos/burgers_oo.py
@@ -21,6 +21,9 @@ from firedrake import *
 from pyroteus_adjoint import *
 
 
+set_log_level(DEBUG)
+
+
 class BurgersMeshSeq(AdjointMeshSeq):
     @staticmethod
     def get_function_spaces(mesh):
@@ -110,7 +113,7 @@ end_time = 0.5
 dt = 1 / n
 num_subintervals = len(meshes)
 P = TimePartition(
-    end_time, num_subintervals, dt, ["u"], timesteps_per_export=2, debug=True
+    end_time, num_subintervals, dt, ["u"], num_timesteps_per_export=2
 )
 mesh_seq = BurgersMeshSeq(P, meshes, qoi_type="end_time")
 solutions = mesh_seq.solve_adjoint()

--- a/demos/burgers_time_integrated.py
+++ b/demos/burgers_time_integrated.py
@@ -117,7 +117,7 @@ end_time = 0.5
 dt = 1 / n
 num_subintervals = len(meshes)
 time_partition = TimePartition(
-    end_time, num_subintervals, dt, ["u"], timesteps_per_export=2
+    end_time, num_subintervals, dt, ["u"], num_timesteps_per_export=2
 )
 
 # The only difference when defining the :class:`AdjointMeshSeq`

--- a/demos/gray_scott.py
+++ b/demos/gray_scott.py
@@ -136,7 +136,7 @@ time_partition = TimePartition(
     num_subintervals,
     dt,
     fields,
-    timesteps_per_export=dt_per_export,
+    num_timesteps_per_export=dt_per_export,
     subintervals=[
         (0.0, 0.001),
         (0.001, 0.01),

--- a/demos/gray_scott_split.py
+++ b/demos/gray_scott_split.py
@@ -144,7 +144,7 @@ time_partition = TimePartition(
     num_subintervals,
     dt,
     fields,
-    timesteps_per_export=dt_per_export,
+    num_timesteps_per_export=dt_per_export,
     subintervals=[
         (0.0, 0.001),
         (0.001, 0.01),

--- a/demos/mesh_seq.py
+++ b/demos/mesh_seq.py
@@ -29,7 +29,7 @@ time_partition = TimePartition(
     len(subintervals),
     dt,
     fields,
-    timesteps_per_export=[2, 4],
+    num_timesteps_per_export=[2, 4],
     subintervals=subintervals,
 )
 

--- a/demos/solid_body_rotation.py
+++ b/demos/solid_body_rotation.py
@@ -106,7 +106,7 @@ time_partition = TimeInterval(
     end_time,
     dt,
     fields,
-    timesteps_per_export=25,
+    num_timesteps_per_export=25,
 )
 
 # For the purposes of plotting, we set up a :class:`MeshSeq` with

--- a/demos/solid_body_rotation_split.py
+++ b/demos/solid_body_rotation_split.py
@@ -73,7 +73,7 @@ time_partition = TimeInterval(
     end_time,
     dt,
     fields,
-    timesteps_per_export=25,
+    num_timesteps_per_export=25,
 )
 mesh_seq = AdjointMeshSeq(
     time_partition,

--- a/demos/time_partition.py
+++ b/demos/time_partition.py
@@ -64,7 +64,7 @@ set_log_level(DEBUG)
 P = TimePartition(end_time, num_subintervals, dt, fields)
 
 # Notice that one of the things which is printed
-# out is ``timesteps_per_export``, which controls
+# out is ``num_timesteps_per_export``, which controls
 # how frequently data is to be exported to file
 # during a simulation. It defaults to one, but may
 # be specified as a keyword argument.
@@ -81,7 +81,7 @@ P = TimePartition(end_time, num_subintervals, dt, fields)
 # than one subinterval. ::
 
 num_subintervals = 2
-P = TimePartition(end_time, num_subintervals, dt, fields, timesteps_per_export=2)
+P = TimePartition(end_time, num_subintervals, dt, fields, num_timesteps_per_export=2)
 
 # In some problems, the dynamics evolve such
 # that different timesteps are suitable during
@@ -90,14 +90,14 @@ P = TimePartition(end_time, num_subintervals, dt, fields, timesteps_per_export=2
 # timesteps corresponding to each subinterval. ::
 
 dt = [0.125, 0.0625]
-P = TimePartition(end_time, num_subintervals, dt, fields, timesteps_per_export=2)
+P = TimePartition(end_time, num_subintervals, dt, fields, num_timesteps_per_export=2)
 
 # Note that this means that there are more
 # exports in the second subinterval than the first.
 # This can be remedied by also setting
-# ``timesteps_per_export`` as a list. ::
+# ``num_timesteps_per_export`` as a list. ::
 
-P = TimePartition(end_time, num_subintervals, dt, fields, timesteps_per_export=[2, 4])
+P = TimePartition(end_time, num_subintervals, dt, fields, num_timesteps_per_export=[2, 4])
 
 # So far, we have assumed that the subintervals
 # are of uniform length. This need not be the case.
@@ -111,7 +111,7 @@ P = TimePartition(
     num_subintervals,
     dt,
     fields,
-    timesteps_per_export=[2, 4],
+    num_timesteps_per_export=[2, 4],
     subintervals=subintervals,
 )
 

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -246,7 +246,7 @@ class AdjointMeshSeq(MeshSeq):
                         label: [
                             [
                                 Function(fs, name=f"{field}_{label}")
-                                for j in range(P.exports_per_subinterval[i] - 1)
+                                for j in range(P.num_exports_per_subinterval[i] - 1)
                             ]
                             for i, fs in enumerate(function_spaces[field])
                         ]
@@ -282,7 +282,7 @@ class AdjointMeshSeq(MeshSeq):
         seeds = None
         for i in reversed(range(num_subintervals)):
             stride = P.num_timesteps_per_export[i]
-            num_exports = P.exports_per_subinterval[i]
+            num_exports = P.num_exports_per_subinterval[i]
 
             # Annotate tape on current subinterval
             checkpoint = wrapped_solver(i, checkpoints[i], **solver_kwargs)

--- a/pyroteus/adjoint.py
+++ b/pyroteus/adjoint.py
@@ -281,7 +281,7 @@ class AdjointMeshSeq(MeshSeq):
         # Loop over subintervals in reverse
         seeds = None
         for i in reversed(range(num_subintervals)):
-            stride = P.timesteps_per_export[i]
+            stride = P.num_timesteps_per_export[i]
             num_exports = P.exports_per_subinterval[i]
 
             # Annotate tape on current subinterval

--- a/pyroteus/go_mesh_seq.py
+++ b/pyroteus/go_mesh_seq.py
@@ -148,7 +148,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                     [
                         Function(fs, name=f"{field}_error_indicator")
                         for _ in range(
-                            self.time_partition.exports_per_subinterval[i] - 1
+                            self.time_partition.num_exports_per_subinterval[i] - 1
                         )
                     ]
                     for i, fs in enumerate(P0_spaces)

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -513,7 +513,7 @@ class MeshSeq:
                         label: [
                             [
                                 Function(fs, name=f"{field}_{label}")
-                                for j in range(P.exports_per_subinterval[i] - 1)
+                                for j in range(P.num_exports_per_subinterval[i] - 1)
                             ]
                             for i, fs in enumerate(function_spaces[field])
                         ]
@@ -532,7 +532,7 @@ class MeshSeq:
         checkpoint = self.initial_condition
         for i in range(num_subintervals):
             stride = P.num_timesteps_per_export[i]
-            num_exports = P.exports_per_subinterval[i]
+            num_exports = P.num_exports_per_subinterval[i]
 
             # Annotate tape on current subinterval
             checkpoint = solver(i, checkpoint, **solver_kwargs)

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -531,7 +531,7 @@ class MeshSeq:
         # Loop over the subintervals
         checkpoint = self.initial_condition
         for i in range(num_subintervals):
-            stride = P.timesteps_per_export[i]
+            stride = P.num_timesteps_per_export[i]
             num_exports = P.exports_per_subinterval[i]
 
             # Annotate tape on current subinterval

--- a/pyroteus/plot.py
+++ b/pyroteus/plot.py
@@ -43,7 +43,7 @@ def plot_snapshots(solutions, time_partition, field, label, **kwargs):
             if not steady:
                 time = (
                     i * P.end_time / cols
-                    + j * P.timesteps_per_export[i] * P.timesteps[i]
+                    + j * P.num_timesteps_per_export[i] * P.timesteps[i]
                 )
                 ax.annotate(f"t={time:.2f}", (0.05, 0.05), color="white")
         tcs.append(tc)
@@ -81,7 +81,7 @@ def plot_indicator_snapshots(indicators, time_partition, field, **kwargs):
             if not steady:
                 time = (
                     i * P.end_time / cols
-                    + j * P.timesteps_per_export[i] * P.timesteps[i]
+                    + j * P.num_timesteps_per_export[i] * P.timesteps[i]
                 )
                 ax.annotate(f"t={time:.2f}", (0.05, 0.05), color="white")
         tcs.append(tc)

--- a/pyroteus/plot.py
+++ b/pyroteus/plot.py
@@ -27,7 +27,7 @@ def plot_snapshots(solutions, time_partition, field, label, **kwargs):
         ``'adjoint'`` and ``'adjoint_next'``
     """
     P = time_partition
-    rows = P.exports_per_subinterval[0] - 1
+    rows = P.num_exports_per_subinterval[0] - 1
     cols = P.num_subintervals
     steady = rows == cols == 1
     figsize = kwargs.pop("figsize", (6 * cols, 24 // cols))
@@ -65,7 +65,7 @@ def plot_indicator_snapshots(indicators, time_partition, field, **kwargs):
         object used to solve the problem
     """
     P = time_partition
-    rows = P.exports_per_subinterval[0] - 1
+    rows = P.num_exports_per_subinterval[0] - 1
     cols = P.num_subintervals
     steady = rows == cols == 1
     figsize = kwargs.pop("figsize", (6 * cols, 24 // cols))

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -25,7 +25,7 @@ class TimePartition:
         num_subintervals: int,
         timesteps: Union[List[float], float],
         fields: Union[List[str], str],
-        timesteps_per_export: int = 1,
+        num_timesteps_per_export: int = 1,
         start_time: float = 0.0,
         subintervals: Optional[List[float]] = None,
     ):
@@ -34,7 +34,7 @@ class TimePartition:
         :arg num_subintervals: number of subintervals in the partition
         :arg timesteps: (list of values for the) timestep used on each subinterval
         :arg fields: (list of) field names ordered by call sequence
-        :kwarg timesteps_per_export: (list of) timesteps per export
+        :kwarg num_timesteps_per_export: (list of) timesteps per export
         :kwarg start_time: start time of the interval of interest
         :kwarg subinterals: user-provided sequence of subintervals, which need not be of
             uniform length
@@ -87,24 +87,24 @@ class TimePartition:
                 )
         self.debug("num_timesteps_per_subinterval")
 
-        # Get timesteps per export
-        if not isinstance(timesteps_per_export, Iterable):
-            if not np.isclose(timesteps_per_export, np.round(timesteps_per_export)):
+        # Get num timesteps per export
+        if not isinstance(num_timesteps_per_export, Iterable):
+            if not np.isclose(num_timesteps_per_export, np.round(num_timesteps_per_export)):
                 raise ValueError(
-                    f"Non-integer timesteps per export ({timesteps_per_export})."
+                    f"Non-integer timesteps per export ({num_timesteps_per_export})."
                 )
-            timesteps_per_export = [
-                int(np.round(timesteps_per_export)) for subinterval in self.subintervals
+            num_timesteps_per_export = [
+                int(np.round(num_timesteps_per_export)) for subinterval in self.subintervals
             ]
-        self.timesteps_per_export = np.array(timesteps_per_export, dtype=np.int32)
-        if len(self.timesteps_per_export) != len(self.num_timesteps_per_subinterval):
+        self.num_timesteps_per_export = np.array(num_timesteps_per_export, dtype=np.int32)
+        if len(self.num_timesteps_per_export) != len(self.num_timesteps_per_subinterval):
             raise ValueError(
                 "Number of timesteps per export and subinterval do not match"
-                f" ({len(self.timesteps_per_export)}"
+                f" ({len(self.num_timesteps_per_export)}"
                 f" vs. {len(self.num_timesteps_per_subinterval)})."
             )
         for i, (tspe, tsps) in enumerate(
-            zip(self.timesteps_per_export, self.num_timesteps_per_subinterval)
+            zip(self.num_timesteps_per_export, self.num_timesteps_per_subinterval)
         ):
             if tsps % tspe != 0:
                 raise ValueError(
@@ -112,14 +112,14 @@ class TimePartition:
                     f" timesteps per subinterval ({tspe} vs. {tsps}"
                     f" on subinterval {i})."
                 )
-        self.debug("timesteps_per_export")
+        self.debug("num_timesteps_per_export")
 
         # Get exports per subinterval
         self.exports_per_subinterval = np.array(
             [
                 tsps // tspe + 1
                 for tspe, tsps in zip(
-                    self.timesteps_per_export, self.num_timesteps_per_subinterval
+                    self.num_timesteps_per_export, self.num_timesteps_per_subinterval
                 )
             ],
             dtype=np.int32,
@@ -171,7 +171,7 @@ class TimePartition:
             {
                 "subinterval": self.subintervals[i],
                 "timestep": self.timesteps[i],
-                "timesteps_per_export": self.timesteps_per_export[i],
+                "num_timesteps_per_export": self.num_timesteps_per_export[i],
                 "num_exports": self.exports_per_subinterval[i],
                 "num_timesteps": self.num_timesteps_per_subinterval[i],
                 "start_time": self.subintervals[i][0],

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -76,16 +76,16 @@ class TimePartition:
         self.debug("timesteps")
 
         # Get number of timesteps on each subinterval
-        self.timesteps_per_subinterval = []
+        self.num_timesteps_per_subinterval = []
         for i, ((ts, tf), dt) in enumerate(zip(self.subintervals, self.timesteps)):
             num_timesteps = (tf - ts) / dt
-            self.timesteps_per_subinterval.append(int(np.round(num_timesteps)))
-            if not np.isclose(num_timesteps, self.timesteps_per_subinterval[-1]):
+            self.num_timesteps_per_subinterval.append(int(np.round(num_timesteps)))
+            if not np.isclose(num_timesteps, self.num_timesteps_per_subinterval[-1]):
                 raise ValueError(
                     f"Non-integer number of timesteps on subinterval {i}:"
                     f" {num_timesteps}."
                 )
-        self.debug("timesteps_per_subinterval")
+        self.debug("num_timesteps_per_subinterval")
 
         # Get timesteps per export
         if not isinstance(timesteps_per_export, Iterable):
@@ -97,14 +97,14 @@ class TimePartition:
                 int(np.round(timesteps_per_export)) for subinterval in self.subintervals
             ]
         self.timesteps_per_export = np.array(timesteps_per_export, dtype=np.int32)
-        if len(self.timesteps_per_export) != len(self.timesteps_per_subinterval):
+        if len(self.timesteps_per_export) != len(self.num_timesteps_per_subinterval):
             raise ValueError(
                 "Number of timesteps per export and subinterval do not match"
                 f" ({len(self.timesteps_per_export)}"
-                f" vs. {len(self.timesteps_per_subinterval)})."
+                f" vs. {len(self.num_timesteps_per_subinterval)})."
             )
         for i, (tspe, tsps) in enumerate(
-            zip(self.timesteps_per_export, self.timesteps_per_subinterval)
+            zip(self.timesteps_per_export, self.num_timesteps_per_subinterval)
         ):
             if tsps % tspe != 0:
                 raise ValueError(
@@ -119,14 +119,14 @@ class TimePartition:
             [
                 tsps // tspe + 1
                 for tspe, tsps in zip(
-                    self.timesteps_per_export, self.timesteps_per_subinterval
+                    self.timesteps_per_export, self.num_timesteps_per_subinterval
                 )
             ],
             dtype=np.int32,
         )
         self.debug("exports_per_subinterval")
         self.steady = (
-            self.num_subintervals == 1 and self.timesteps_per_subinterval[0] == 1
+            self.num_subintervals == 1 and self.num_timesteps_per_subinterval[0] == 1
         )
         self.debug("steady")
         debug(100 * "-")
@@ -173,7 +173,7 @@ class TimePartition:
                 "timestep": self.timesteps[i],
                 "timesteps_per_export": self.timesteps_per_export[i],
                 "num_exports": self.exports_per_subinterval[i],
-                "num_timesteps": self.timesteps_per_subinterval[i],
+                "num_timesteps": self.num_timesteps_per_subinterval[i],
                 "start_time": self.subintervals[i][0],
                 "end_time": self.subintervals[i][1],
             }

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -65,11 +65,7 @@ class TimePartition:
                 )
                 for i in range(num_subintervals)
             ]
-        assert len(self.subintervals) == num_subintervals
-        assert np.isclose(self.subintervals[0][0], self.start_time)
-        for i in range(1, num_subintervals):
-            assert np.isclose(self.subintervals[i][0], self.subintervals[i - 1][1])
-        assert np.isclose(self.subintervals[-1][1], self.end_time)
+        self._check_subintervals()
         self.debug("subintervals")
 
         # Get timestep on each subinterval
@@ -188,6 +184,30 @@ class TimePartition:
                 "end_time": self.subintervals[i][1],
             }
         )
+
+    def _check_subintervals(self):
+        if len(self.subintervals) != self.num_subintervals:
+            raise ValueError(
+                "Number of subintervals provided differs from num_subintervals:"
+                f" {len(self.subintervals)} != {self.num_subintervals}."
+            )
+        if not np.isclose(self.subintervals[0][0], self.start_time):
+            raise ValueError(
+                "The first subinterval does not start at the start time:"
+                f" {self.subintervals[0][0]} != {self.start_time}."
+            )
+        for i in range(self.num_subintervals-1):
+            if not np.isclose(self.subintervals[i][1], self.subintervals[i+1][0]):
+                raise ValueError(
+                    f"The end of subinterval {i} does not match the start of"
+                    f" subinterval {i+1}: {self.subintervals[i][1]} !="
+                    f" {self.subintervals[i+1][0]}."
+                )
+        if not np.isclose(self.subintervals[-1][1], self.end_time):
+            raise ValueError(
+                "The final subinterval does not end at the end time:"
+                f" {self.subintervals[-1][1]} != {self.end_time}."
+            )
 
     def __eq__(self, other):
         if len(self) != len(other):

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -270,13 +270,14 @@ class TimeInstant(TimeInterval):
     """
 
     def __init__(self, fields: Union[List[str], str], **kwargs):
-        time = kwargs.get("time", 1.0)
         if "end_time" in kwargs:
             if "time" in kwargs:
                 raise ValueError("Both 'time' and 'end_time' are set.")
-            time = kwargs.get("end_time")
+            time = kwargs.pop("end_time")
+        else:
+            time = kwargs.pop("time", 1.0)
         timestep = time
-        super().__init__(time, timestep, fields)
+        super().__init__(time, timestep, fields, **kwargs)
 
     def __str__(self) -> str:
         return f"({self.end_time})"

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -94,17 +94,14 @@ class TimePartition:
         self._check_num_timesteps_per_export()
         self.debug("num_timesteps_per_export")
 
-        # Get exports per subinterval
-        self.exports_per_subinterval = np.array(
-            [
-                tsps // tspe + 1
-                for tspe, tsps in zip(
-                    self.num_timesteps_per_export, self.num_timesteps_per_subinterval
-                )
-            ],
-            dtype=np.int32,
-        )
-        self.debug("exports_per_subinterval")
+        # Get num exports per subinterval
+        self.num_exports_per_subinterval = [
+            tsps // tspe + 1
+            for tspe, tsps in zip(
+                self.num_timesteps_per_export, self.num_timesteps_per_subinterval
+            )
+        ]
+        self.debug("num_exports_per_subinterval")
         self.steady = (
             self.num_subintervals == 1 and self.num_timesteps_per_subinterval[0] == 1
         )
@@ -152,7 +149,7 @@ class TimePartition:
                 "subinterval": self.subintervals[i],
                 "timestep": self.timesteps[i],
                 "num_timesteps_per_export": self.num_timesteps_per_export[i],
-                "num_exports": self.exports_per_subinterval[i],
+                "num_exports": self.num_exports_per_subinterval[i],
                 "num_timesteps": self.num_timesteps_per_subinterval[i],
                 "start_time": self.subintervals[i][0],
                 "end_time": self.subintervals[i][1],
@@ -218,7 +215,7 @@ class TimePartition:
         return (
             np.allclose(self.subintervals, other.subintervals)
             and np.allclose(self.timesteps, other.timesteps)
-            and np.allclose(self.exports_per_subinterval, other.exports_per_subinterval)
+            and np.allclose(self.num_exports_per_subinterval, other.num_exports_per_subinterval)
             and self.fields == other.fields
         )
 
@@ -229,7 +226,7 @@ class TimePartition:
             not np.allclose(self.subintervals, other.subintervals)
             or not np.allclose(self.timesteps, other.timesteps)
             or not np.allclose(
-                self.exports_per_subinterval, other.exports_per_subinterval
+                self.num_exports_per_subinterval, other.num_exports_per_subinterval
             )
             or not self.fields == other.fields
         )

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -5,7 +5,7 @@ from .log import debug
 from .utility import AttrDict
 from collections.abc import Iterable
 import numpy as np
-from typing import List, Union
+from typing import List, Optional, Union
 
 
 __all__ = ["TimePartition", "TimeInterval", "TimeInstant"]
@@ -13,12 +13,10 @@ __all__ = ["TimePartition", "TimeInterval", "TimeInstant"]
 
 class TimePartition:
     """
-    Object describing the partition of the time
-    interval of interest into subintervals.
+    A partition of the time interval of interest into subintervals.
 
-    For now, the subintervals are assumed to be
-    uniform in length. However, different values
-    may be used of the timestep on each.
+    The subintervals are assumed to be uniform in length. However, different timestep
+    values may be used on each subinterval.
     """
 
     def __init__(
@@ -27,31 +25,25 @@ class TimePartition:
         num_subintervals: int,
         timesteps: Union[List[float], float],
         fields: Union[List[str], str],
-        **kwargs,
+        timesteps_per_export: int = 1,
+        start_time: float = 0.0,
+        subintervals: Optional[List[float]] = None,
     ):
         """
-        :arg end_time: end time of the interval
-            of interest
-        :arg num_subintervals: number of
-            subintervals in the partition
-        :arg timesteps: (list of values for the)
-            timestep used on each subinterval
-        :arg fields: (list of) field names ordered
-            by call sequence
-        :kwarg timesteps_per_export: (list of)
-            timesteps per export (default 1)
-        :kwarg start_time: start time of the
-            interval of interest (default 0.0)
-        :kwarg subinterals: user-provided sequence
-            of subintervals, which need not be of
-            uniform length (defaults to None)
+        :arg end_time: end time of the interval of interest
+        :arg num_subintervals: number of subintervals in the partition
+        :arg timesteps: (list of values for the) timestep used on each subinterval
+        :arg fields: (list of) field names ordered by call sequence
+        :kwarg timesteps_per_export: (list of) timesteps per export
+        :kwarg start_time: start time of the interval of interest
+        :kwarg subinterals: user-provided sequence of subintervals, which need not be of
+            uniform length
         """
         debug(100 * "-")
         if isinstance(fields, str):
             fields = [fields]
         self.fields = fields
-        timesteps_per_export = kwargs.get("timesteps_per_export", 1)
-        self.start_time = kwargs.get("start_time", 0.0)
+        self.start_time = start_time
         self.end_time = end_time
         self.num_subintervals = int(np.round(num_subintervals))
         if not np.isclose(num_subintervals, self.num_subintervals):
@@ -63,7 +55,7 @@ class TimePartition:
         self.debug("interval")
 
         # Get subintervals
-        self.subintervals = kwargs.get("subintervals")
+        self.subintervals = subintervals
         if self.subintervals is None:
             subinterval_time = (self.end_time - self.start_time) / num_subintervals
             self.subintervals = [

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -33,8 +33,8 @@ class TimePartition:
         :arg end_time: end time of the interval of interest
         :arg num_subintervals: number of subintervals in the partition
         :arg timesteps: (list of values for the) timestep used on each subinterval
-        :arg fields: (list of) field names ordered by call sequence
-        :kwarg num_timesteps_per_export: (list of) timesteps per export
+        :arg fields: (list of) field names
+        :kwarg num_timesteps_per_export: (list of) number of timesteps per export
         :kwarg start_time: start time of the interval of interest
         :kwarg subinterals: user-provided sequence of subintervals, which need not be of
             uniform length

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -76,17 +76,15 @@ class TimePartition:
         self.debug("timesteps")
 
         # Get number of timesteps on each subinterval
-        _timesteps_per_subinterval = [
-            (t[1] - t[0]) / dt for t, dt in zip(self.subintervals, self.timesteps)
-        ]
-        self.timesteps_per_subinterval = [
-            int(np.round(tsps)) for tsps in _timesteps_per_subinterval
-        ]
-        if not np.allclose(self.timesteps_per_subinterval, _timesteps_per_subinterval):
-            raise ValueError(
-                "Non-integer timesteps per subinterval"
-                f" ({_timesteps_per_subinterval})."
-            )
+        self.timesteps_per_subinterval = []
+        for i, ((ts, tf), dt) in enumerate(zip(self.subintervals, self.timesteps)):
+            num_timesteps = (tf - ts) / dt
+            self.timesteps_per_subinterval.append(int(np.round(num_timesteps)))
+            if not np.isclose(num_timesteps, self.timesteps_per_subinterval[-1]):
+                raise ValueError(
+                    f"Non-integer number of timesteps on subinterval {i}:"
+                    f" {num_timesteps}."
+                )
         self.debug("timesteps_per_subinterval")
 
         # Get timesteps per export

--- a/pyroteus/time_partition.py
+++ b/pyroteus/time_partition.py
@@ -70,14 +70,10 @@ class TimePartition:
 
         # Get timestep on each subinterval
         if not isinstance(timesteps, Iterable):
-            timesteps = [timesteps for subinterval in self.subintervals]
-        self.timesteps = np.array(timesteps)
+            timesteps = [timesteps] * len(self)
+        self.timesteps = timesteps
+        self._check_timesteps()
         self.debug("timesteps")
-        if len(self.timesteps) != num_subintervals:
-            raise ValueError(
-                "Number of timesteps and subintervals do not match"
-                f" ({len(self.timesteps)} vs. {num_subintervals})."
-            )
 
         # Get number of timesteps on each subinterval
         _timesteps_per_subinterval = [
@@ -207,6 +203,13 @@ class TimePartition:
             raise ValueError(
                 "The final subinterval does not end at the end time:"
                 f" {self.subintervals[-1][1]} != {self.end_time}."
+            )
+
+    def _check_timesteps(self):
+        if len(self.timesteps) != self.num_subintervals:
+            raise ValueError(
+                "Number of timesteps does not match num_subintervals:"
+                f" {len(self.timesteps)} != {self.num_subintervals}."
             )
 
     def __eq__(self, other):

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -142,15 +142,18 @@ class TestSetup(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg)
 
     def test_noninteger_num_timesteps_per_export(self):
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(TypeError) as cm:
             TimePartition(1.0, 1, [0.5], "field", num_timesteps_per_export=1.1)
-        msg = "Non-integer timesteps per export (1.1)."
+        msg = (
+            "Expected number of timesteps per export on subinterval 0 to be an integer,"
+            " not '<class 'float'>'."
+        )
         self.assertEqual(str(cm.exception), msg)
 
     def test_nonmatching_num_num_timesteps_per_export(self):
         with self.assertRaises(ValueError) as cm:
             TimePartition(1.0, 1, [0.5], "field", num_timesteps_per_export=[1, 2])
-        msg = "Number of timesteps per export and subinterval do not match (2 vs. 1)."
+        msg = "Number of timesteps per export and subinterval do not match: 2 != 1."
         self.assertEqual(str(cm.exception), msg)
 
     def test_indivisible_num_timesteps_per_export(self):
@@ -158,7 +161,7 @@ class TestSetup(unittest.TestCase):
             TimePartition(1.0, 1, [0.5], "field", num_timesteps_per_export=4)
         msg = (
             "Number of timesteps per export does not divide number of timesteps per"
-            " subinterval (4 vs. 2 on subinterval 0)."
+            " subinterval on subinterval 0: 2 | 4 != 0."
         )
         self.assertEqual(str(cm.exception), msg)
 

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -135,7 +135,7 @@ class TestSetup(unittest.TestCase):
         msg = "Number of timesteps does not match num_subintervals: 2 != 1."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_noninteger_timesteps_per_subinterval(self):
+    def test_noninteger_num_timesteps_per_subinterval(self):
         with self.assertRaises(ValueError) as cm:
             TimePartition(1.0, 1, [0.4], "field")
         msg = "Non-integer number of timesteps on subinterval 0: 2.5."

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -150,7 +150,7 @@ class TestSetup(unittest.TestCase):
         )
         self.assertEqual(str(cm.exception), msg)
 
-    def test_nonmatching_num_num_timesteps_per_export(self):
+    def test_nonmatching_num_timesteps_per_export(self):
         with self.assertRaises(ValueError) as cm:
             TimePartition(1.0, 1, [0.5], "field", num_timesteps_per_export=[1, 2])
         msg = "Number of timesteps per export and subinterval do not match: 2 != 1."

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -138,7 +138,7 @@ class TestSetup(unittest.TestCase):
     def test_noninteger_timesteps_per_subinterval(self):
         with self.assertRaises(ValueError) as cm:
             TimePartition(1.0, 1, [0.4], "field")
-        msg = "Non-integer timesteps per subinterval ([2.5])."
+        msg = "Non-integer number of timesteps on subinterval 0: 2.5."
         self.assertEqual(str(cm.exception), msg)
 
     def test_noninteger_timesteps_per_export(self):

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -32,7 +32,7 @@ class TestSetup(unittest.TestCase):
         self.assertTrue(time_partition1 != time_partition2)
 
     def test_time_partition_ne_negative(self):
-        time_partition1 = TimePartition(1.0, 1, [1.0], "field", timesteps_per_export=1)
+        time_partition1 = TimePartition(1.0, 1, [1.0], "field", num_timesteps_per_export=1)
         time_partition2 = TimePartition(1.0, 1, [1.0], "field")
         self.assertFalse(time_partition1 != time_partition2)
 
@@ -141,21 +141,21 @@ class TestSetup(unittest.TestCase):
         msg = "Non-integer number of timesteps on subinterval 0: 2.5."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_noninteger_timesteps_per_export(self):
+    def test_noninteger_num_timesteps_per_export(self):
         with self.assertRaises(ValueError) as cm:
-            TimePartition(1.0, 1, [0.5], "field", timesteps_per_export=1.1)
+            TimePartition(1.0, 1, [0.5], "field", num_timesteps_per_export=1.1)
         msg = "Non-integer timesteps per export (1.1)."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_nonmatching_num_timesteps_per_export(self):
+    def test_nonmatching_num_num_timesteps_per_export(self):
         with self.assertRaises(ValueError) as cm:
-            TimePartition(1.0, 1, [0.5], "field", timesteps_per_export=[1, 2])
+            TimePartition(1.0, 1, [0.5], "field", num_timesteps_per_export=[1, 2])
         msg = "Number of timesteps per export and subinterval do not match (2 vs. 1)."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_indivisible_timesteps_per_export(self):
+    def test_indivisible_num_timesteps_per_export(self):
         with self.assertRaises(ValueError) as cm:
-            TimePartition(1.0, 1, [0.5], "field", timesteps_per_export=4)
+            TimePartition(1.0, 1, [0.5], "field", num_timesteps_per_export=4)
         msg = (
             "Number of timesteps per export does not divide number of timesteps per"
             " subinterval (4 vs. 2 on subinterval 0)."

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -96,10 +96,37 @@ class TestSetup(unittest.TestCase):
         time_interval = TimeInterval(1.0, 0.5, "field")
         self.assertFalse(time_partition != time_interval)
 
-    def test_noninteger_subintervals(self):
+    def test_noninteger_num_subintervals(self):
         with self.assertRaises(ValueError) as cm:
             TimePartition(1.0, 1.1, 0.5, "field")
         msg = "Non-integer number of subintervals '1.1'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_wrong_number_of_subintervals(self):
+        with self.assertRaises(ValueError) as cm:
+            TimePartition(1.0, 1, 0.5, "field", subintervals=[(0.0, 0.5), (0.5, 1.0)])
+        msg = "Number of subintervals provided differs from num_subintervals: 2 != 1."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_wrong_subinterval_start(self):
+        with self.assertRaises(ValueError) as cm:
+            TimePartition(1.0, 1, 0.5, "field", subintervals=[(0.1, 1.0)])
+        msg = "The first subinterval does not start at the start time: 0.1 != 0.0."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_inconsistent_subintervals(self):
+        with self.assertRaises(ValueError) as cm:
+            TimePartition(1.0, 2, 0.5, "field", subintervals=[(0.0, 0.6), (0.5, 1.0)])
+        msg = (
+            "The end of subinterval 0 does not match the start of subinterval 1:"
+            " 0.6 != 0.5."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_wrong_subinterval_end(self):
+        with self.assertRaises(ValueError) as cm:
+            TimePartition(1.0, 1, 0.5, "field", subintervals=[(0.0, 1.1)])
+        msg = "The final subinterval does not end at the end time: 1.1 != 1.0."
         self.assertEqual(str(cm.exception), msg)
 
     def test_wrong_num_timesteps(self):

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -132,7 +132,7 @@ class TestSetup(unittest.TestCase):
     def test_wrong_num_timesteps(self):
         with self.assertRaises(ValueError) as cm:
             TimePartition(1.0, 1, [0.5, 0.5], "field")
-        msg = "Number of timesteps and subintervals do not match (2 vs. 1)."
+        msg = "Number of timesteps does not match num_subintervals: 2 != 1."
         self.assertEqual(str(cm.exception), msg)
 
     def test_noninteger_timesteps_per_subinterval(self):

--- a/test_adjoint/test_adjoint.py
+++ b/test_adjoint/test_adjoint.py
@@ -124,7 +124,7 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
         end_time,
         test_case.dt,
         test_case.fields,
-        timesteps_per_export=test_case.dt_per_export,
+        num_timesteps_per_export=test_case.dt_per_export,
     )
     mesh_seq = AdjointMeshSeq(
         time_partition,
@@ -174,7 +174,7 @@ def test_adjoint_same_mesh(problem, qoi_type, debug=False):
             N,
             test_case.dt,
             test_case.fields,
-            timesteps_per_export=test_case.dt_per_export,
+            num_timesteps_per_export=test_case.dt_per_export,
         )
         mesh_seq = AdjointMeshSeq(
             time_partition,
@@ -245,7 +245,7 @@ def plot_solutions(problem, qoi_type, debug=True):
         end_time,
         test_case.dt,
         test_case.fields,
-        timesteps_per_export=test_case.dt_per_export,
+        num_timesteps_per_export=test_case.dt_per_export,
     )
     solutions = AdjointMeshSeq(
         time_partition,

--- a/test_adjoint/test_adjoint.py
+++ b/test_adjoint/test_adjoint.py
@@ -270,7 +270,7 @@ def plot_solutions(problem, qoi_type, debug=True):
         outfiles.adjoint_next = File(os.path.join(output_dir, "adjoint_next.pvd"))
         outfiles.adj_value = File(os.path.join(output_dir, "adj_value.pvd"))
     for label in outfiles:
-        for k in range(time_partition.exports_per_subinterval[0] - 1):
+        for k in range(time_partition.num_exports_per_subinterval[0] - 1):
             to_plot = []
             for field in time_partition.fields:
                 sol = solutions[field][label][0][k]


### PR DESCRIPTION
Closes #158.

Nothing too interesting to see here - will self-review.

However, note that there are three variable renamings:
* `timesteps_per_subinterval` -> `num_timesteps_per_subinterval`
* `timesteps_per_export` -> `num_timesteps_per_export`
* `exports_per_subinterval` -> `num_exports_per_subinterval`