### PR TITLE
Introduce field types

### DIFF
--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -58,6 +58,10 @@ class MeshSeq:
         """
         self.time_partition = time_partition
         self.fields = time_partition.fields
+        self.field_types = {
+            field: field_type
+            for field, field_type in zip(self.fields, time_partition.field_types)
+        }
         self.subintervals = time_partition.subintervals
         self.num_subintervals = time_partition.num_subintervals
         self.meshes = initial_meshes
@@ -434,6 +438,8 @@ class MeshSeq:
         :arg subinterval: subinterval index
         :arg solve_block: taped :class:`firedrake.adjoint.blocks.GenericSolveBlock`
         """
+        if self.field_types[field] == "unsteady":
+            return
         fs = self.function_spaces[field][subinterval]
         assert isinstance(solve_block, GenericSolveBlock)
 

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -4,7 +4,6 @@ Sequences of meshes corresponding to a :class:`~.TimePartition`.
 import firedrake
 from firedrake.petsc import PETSc
 from firedrake.adjoint.solving import get_solve_blocks
-from firedrake.adjoint.blocks import GenericSolveBlock
 from pyadjoint import get_working_tape, Block
 from .interpolation import project
 from .log import pyrint, debug, warning, info, logger, DEBUG

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -391,15 +391,12 @@ class MeshSeq:
         :arg solve_block: taped :class:`firedrake.adjoint.blocks.GenericSolveBlock`
         """
         fs = self.function_spaces[field][subinterval]
-        assert isinstance(solve_block, GenericSolveBlock)
 
         # Loop through the solve block's outputs
         candidates = []
         for out in solve_block._outputs:
             # Look for Functions with matching function spaces
             if not isinstance(out.output, Function):
-                continue
-            if not hasattr(out.output, "function_space"):
                 continue
             if out.output.function_space() != fs:
                 continue
@@ -438,18 +435,15 @@ class MeshSeq:
         :arg subinterval: subinterval index
         :arg solve_block: taped :class:`firedrake.adjoint.blocks.GenericSolveBlock`
         """
-        if self.field_types[field] == "unsteady":
+        if self.field_types[field] == "steady":
             return
         fs = self.function_spaces[field][subinterval]
-        assert isinstance(solve_block, GenericSolveBlock)
 
         # Loop through the solve block's dependencies
         candidates = []
         for dep in solve_block._dependencies:
             # Look for Functions with matching function spaces
             if not isinstance(dep.output, Function):
-                continue
-            if not hasattr(dep.output, "function_space"):
                 continue
             if dep.output.function_space() != fs:
                 continue

--- a/pyroteus/mesh_seq.py
+++ b/pyroteus/mesh_seq.py
@@ -404,8 +404,6 @@ class MeshSeq:
             # Look for Functions whose name matches that of the field
             # NOTE: Here we assume that the user has set this correctly in their
             #       get_solver method
-            if not hasattr(out.output, "name"):
-                continue
             if not out.output.name() == field:
                 continue
 
@@ -417,8 +415,8 @@ class MeshSeq:
             return candidates[0]
         elif len(candidates) > 1:
             raise AttributeError(
-                "Cannot determine a unique output for the solution"
-                f" associated with field '{field}'. Candidates: {candidates}."
+                "Cannot determine a unique output index for the solution associated"
+                f" with field '{field}' out of {len(candidates)} candidates."
             )
         elif not self.steady:
             raise AttributeError(
@@ -451,8 +449,6 @@ class MeshSeq:
             # Look for Functions whose name is the lagged version of the field's
             # NOTE: Here we assume that the user has set this correctly in their
             #       get_solver method
-            if not hasattr(dep.output, "name"):
-                continue
             if not dep.output.name() == f"{field}_old":
                 continue
 
@@ -465,7 +461,7 @@ class MeshSeq:
         elif len(candidates) > 1:
             raise AttributeError(
                 "Cannot determine a unique dependency index for the lagged solution"
-                f" associated with field '{field}'. Candidates: {candidates}."
+                f" associated with field '{field}' out of {len(candidates)} candidates."
             )
         elif not self.steady:
             raise AttributeError(

--- a/test/test_mesh_seq.py
+++ b/test/test_mesh_seq.py
@@ -140,24 +140,23 @@ class TestStringFormatting(unittest.TestCase):
         self.assertTrue(re.match(repr(mesh_seq), expected))
 
 
-def get_p0_spaces(mesh):
-    return {"field": FunctionSpace(mesh, "DG", 0)}
-
-
 class TestBlockLogic(unittest.TestCase):
     """
     Unit tests for :meth:`MeshSeq._dependency` and :meth:`MeshSeq._output`.
     """
+    @staticmethod
+    def get_p0_spaces(mesh):
+        return {"field": FunctionSpace(mesh, "DG", 0)}
 
     def setUp(self):
         self.time_interval = TimeInterval(1.0, 0.5, "field")
         self.mesh = UnitTriangleMesh()
+        self.mesh_seq = MeshSeq(
+            self.time_interval, self.mesh, get_function_spaces=self.get_p0_spaces
+        )
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_output_not_function(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(1)
         solve_block._outputs = [block_variable]
@@ -168,9 +167,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_output_wrong_function_space(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(Function(FunctionSpace(self.mesh, "CG", 1)))
         solve_block._outputs = [block_variable]
@@ -181,9 +177,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_output_wrong_name(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "DG", 0)
         block_variable = BlockVariable(Function(function_space, name="field2"))
@@ -195,9 +188,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_output_valid(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "DG", 0)
         block_variable = BlockVariable(Function(function_space, name="field"))
@@ -206,9 +196,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_output_multiple_valid_error(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "DG", 0)
         block_variable = BlockVariable(Function(function_space, name="field"))
@@ -223,9 +210,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_dependency_not_function(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(1)
         solve_block._dependencies = [block_variable]
@@ -236,9 +220,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_dependency_wrong_function_space(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(Function(FunctionSpace(self.mesh, "CG", 1)))
         solve_block._dependencies = [block_variable]
@@ -249,9 +230,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_dependency_wrong_name(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "DG", 0)
         block_variable = BlockVariable(Function(function_space, name="field_new"))
@@ -263,9 +241,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_dependency_valid(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "DG", 0)
         block_variable = BlockVariable(Function(function_space, name="field_old"))
@@ -274,9 +249,6 @@ class TestBlockLogic(unittest.TestCase):
 
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_dependency_multiple_valid_error(self, MockSolveBlock):
-        self.mesh_seq = MeshSeq(
-            self.time_interval, self.mesh, get_function_spaces=get_p0_spaces
-        )
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "DG", 0)
         block_variable = BlockVariable(Function(function_space, name="field_old"))
@@ -292,8 +264,8 @@ class TestBlockLogic(unittest.TestCase):
     @patch("dolfin_adjoint_common.blocks.solving.GenericSolveBlock")
     def test_dependency_steady(self, MockSolveBlock):
         time_interval = TimeInterval(1.0, 0.5, "field", field_types="steady")
-        self.mesh_seq = MeshSeq(
-            time_interval, self.mesh, get_function_spaces=get_p0_spaces
+        mesh_seq = MeshSeq(
+            time_interval, self.mesh, get_function_spaces=self.get_p0_spaces
         )
         solve_block = MockSolveBlock()
-        self.assertIsNone(self.mesh_seq._dependency("field", 0, solve_block))
+        self.assertIsNone(mesh_seq._dependency("field", 0, solve_block))

--- a/test/test_mesh_seq.py
+++ b/test/test_mesh_seq.py
@@ -5,7 +5,6 @@ from pyroteus.mesh_seq import MeshSeq
 from pyroteus.time_partition import TimePartition, TimeInterval
 from firedrake import *
 from pyadjoint.block_variable import BlockVariable
-from dolfin_adjoint_common.blocks.solving import GenericSolveBlock
 import numpy as np
 import re
 import unittest

--- a/test/test_mesh_seq.py
+++ b/test/test_mesh_seq.py
@@ -73,12 +73,21 @@ class TestGeneric(unittest.TestCase):
         mesh_seq.check_element_count_convergence()
         self.assertFalse(mesh_seq.converged)
 
+    def test_counting(self):
+        mesh_seq = MeshSeq(self.time_interval, [UnitSquareMesh(3, 3)])
+        self.assertEqual(mesh_seq.count_elements(), [18])
+        self.assertEqual(mesh_seq.count_vertices(), [16])
 
-class TestStringFormatting(TestGeneric):
+
+class TestStringFormatting(unittest.TestCase):
     """
     Test that the :meth:`__str__` and :meth:`__repr__` methods work as intended for
     Pyroteus' :class:`MeshSeq` object.
     """
+
+    def setUp(self):
+        self.time_partition = TimePartition(1.0, 2, [0.5, 0.5], ["field"])
+        self.time_interval = TimeInterval(1.0, [0.5], ["field"])
 
     def test_mesh_seq_time_interval_str(self):
         mesh_seq = MeshSeq(self.time_interval, [UnitSquareMesh(1, 1)])
@@ -126,14 +135,3 @@ class TestStringFormatting(TestGeneric):
             "Mesh(VectorElement(FiniteElement('Lagrange', triangle, 1), dim=2), .*)])"
         )
         self.assertTrue(re.match(repr(mesh_seq), expected))
-
-
-class TestMeshSeq(TestStringFormatting):
-    """
-    Unit tests for basic :class:`MeshSeq` functionality.
-    """
-
-    def test_counting(self):
-        mesh_seq = MeshSeq(self.time_interval, [UnitSquareMesh(3, 3)])
-        self.assertEqual(mesh_seq.count_elements(), [18])
-        self.assertEqual(mesh_seq.count_vertices(), [16])

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -171,6 +171,21 @@ class TestSetup(unittest.TestCase):
         msg = "Attribute 'blah' cannot be debugged because it doesn't exist."
         self.assertEqual(str(cm.exception), msg)
 
+    def test_field_type_error(self):
+        with self.assertRaises(ValueError) as cm:
+            TimeInstant("field", field_types="type")
+        msg = (
+            "Expected field type for field 'field' to be either 'unsteady' or"
+            " 'steady', but got 'type'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_num_field_types_error(self):
+        with self.assertRaises(ValueError) as cm:
+            TimeInstant("field", field_types=["type1", "type2"])
+        msg = "Number of fields does not match number of field types: 1 != 2."
+        self.assertEqual(str(cm.exception), msg)
+
 
 class TestStringFormatting(unittest.TestCase):
     """


### PR DESCRIPTION
Closes #122.
Will need #159 to be merged first (changes are added on top of that branch).

Okay @ddundo, I *think* this is what's required to fix your problem: introduce a `field_type` associated with each `field`, which says whether it has a time-derivative or not (`unsteady` or `steady`). Can you confirm whether this fixes your issue?